### PR TITLE
Add require deploy to prevent dependency error.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,6 +16,7 @@
 class jira::install {
 
   require jira
+  require deploy
 
   deploy::file { "atlassian-${jira::product}-${jira::version}.${jira::format}":
     target  => "${jira::installdir}/atlassian-${jira::product}-${jira::version}-standalone",


### PR DESCRIPTION
Error: Failed to apply catalog: Could not find dependency File[undef]
for Exec[xxxx] at /etc/puppet/modules/deploy/manifests/file.pp:133
