### PR TITLE
Let puppet work out the appropriate service provider.

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,7 +18,6 @@ class jira::service {
     service { 'jira':
       ensure    => $jira::service_ensure,
       enable    => $jira::service_enable,
-      provider  => base,
       start     => '/etc/init.d/jira start',
       restart   => '/etc/init.d/jira restart',
       stop      => '/etc/init.d/jira stop',


### PR DESCRIPTION
When provider is set to base the 'enable' parameter has no effect and the jira service does not start on reboot.

By not explicitly setting this value puppet should work out the appropriate way to setup the init script to start on boot.
