### PR TITLE
Resolve Issue #29 Replace mkrakowitzer-deploy with nanlui-staging

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@ fixtures:
   symlinks:
     jira: "#{source_dir}"
   repositories:
-    deploy: "git://github.com/mkrakowitzer/puppet-deploy"
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    deploy: "https://github.com/mkrakowitzer/puppet-deploy"
+    staging: "https://github.com/nanliu/puppet-staging"
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+##TBA - Release 1.1.0
+
+###Summary
+Resolve Issue #29
+- Replace mkrakowitzer-deploy with nanlui-staging as the default module to deploy jira files
+
 ##2014-10-01 - Release 1.0.1
 
 ###Summary

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This module installs/upgrades Atlassian's Enterprise Issue Tracking and project 
 
 * JIRA requires a Java Developers Kit (JDK) or Java Run-time Environment (JRE) platform to be installed on your server's operating system. Oracle JDK / JRE (formerly Sun JDK / JRE)	versions 7 and 8 are currently supported by Atlassian.
 
-* JIRA requires a relational database to store its issue data. This module currently supports PostgreSQL 8.4 to 9.x and MySQL 5.x. We suggest using puppetlabs-postgres/puppetlabs-mysql modules to configure/manage the database. The module uses PostgreSQL as a default.
+* JIRA requires a relational database to store its issue data. This module currently supports PostgreSQL 8.4 to 9.x and MySQL 5.x. We suggest using puppetlabs-postgresql/puppetlabs-mysql modules to configure/manage the database. The module uses PostgreSQL as a default.
 
 * Whilst not required, for production use we recommend using nginx/apache as a reverse proxy to JIRA. We suggest using the jfryman/nginx puppet module.
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -36,7 +36,11 @@ class jira::config {
   file { "${jira::webappdir}/bin/user.sh":
     content => template('jira/user.sh.erb'),
     mode    => '0755',
-    require => [ Class['jira::install'], File[$jira::webappdir], File[$jira::homedir] ],
+    require => [
+      Class['jira::install'],
+      File[$jira::webappdir],
+      File[$jira::homedir],
+    ],
   } ->
 
   file { "${jira::webappdir}/bin/setenv.sh":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,12 +97,18 @@ class jira (
   # Misc Settings
   $downloadURL  = 'http://www.atlassian.com/software/jira/downloads/binary/',
 
+  # Choose whether to use nanlui-staging, or mkrakowitzer-deploy
+  # Defaults to nanlui-staging as it is puppetlabs approved.
+  $staging_or_deploy = 'staging',
+
   # Manage service
   $service_manage = true,
   $service_ensure = running,
   $service_enable = true,
+
   # Tomcat
   $tomcatPort = 8080,
+
   # Tomcat Tunables
   $tomcatMaxThreads  = '150',
   $tomcatAcceptCount = '100',

--- a/metadata.json
+++ b/metadata.json
@@ -10,8 +10,8 @@
   "description": "Module to install Jira",
   "dependencies": [
     {
-      "name": "mkrakowitzer/deploy",
-      "version_requirement": ">= 0.0.2"
+      "name": "nanlui/staging",
+      "version_requirement": ">= 1.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/classes/jira_install_deploy_spec.rb
+++ b/spec/classes/jira_install_deploy_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper.rb'
+
+describe 'jira' do
+  describe 'jira::install' do
+    context 'default params' do
+      let(:params) {{
+        :javahome    => '/opt/java',
+        :user        => 'jira',
+        :group       => 'jira',
+        :installdir  => '/opt/jira',
+        :homedir     => '/home/jira',
+        :format      => 'tar.gz',
+        :product     => 'jira',
+        :version     => '6.4.3a',
+        :downloadURL => 'http://www.atlassian.com/software/jira/downloads/binary/',
+	:staging_or_deploy => 'deploy',
+      }}
+      it { should contain_group('jira') }
+      it { should contain_user('jira').with_shell('/bin/true') }
+      it 'should deploy jira 6.4.3a from tar.gz' do
+        should contain_deploy__file("atlassian-jira-6.4.3a.tar.gz")
+      end
+      it 'should manage the jira home directory' do
+        should contain_file('/home/jira').with({
+          'ensure' => 'directory',
+          'owner' => 'jira',
+          'group' => 'jira'
+          })
+      end
+    end
+
+    context 'overwriting params' do
+      let(:params) {{
+        :javahome    => '/opt/java',
+        :version => '6.0.0',
+        :format => 'tar.gz',
+        :installdir => '/opt/jira',
+        :homedir => '/random/homedir',
+        :user  => 'foo',
+        :group => 'bar',
+        :uid   => 333,
+        :gid   => 444,
+        :downloadURL => 'http://downloads.atlassian.com/',
+        :staging_or_deploy => 'deploy',
+      }}
+  
+      it { should contain_user('foo').with({
+          'home'  => '/random/homedir',
+          'shell' => '/bin/true',
+          'uid'   => 333,
+          'gid'   => 444
+        }) }
+      it { should contain_group('bar') }
+  
+      it 'should deploy jira 6.0.0 from tar.gz' do
+        should contain_deploy__file("atlassian-jira-6.0.0.tar.gz").with({
+          'url' => 'http://downloads.atlassian.com/',
+          'owner' => 'foo',
+          'group' => 'bar'
+          })
+      end
+  
+      it 'should manage the jira home directory' do
+        should contain_file('/random/homedir').with({
+          'ensure' => 'directory',
+          'owner' => 'foo',
+          'group' => 'bar'
+          })
+      end
+    end
+  end
+end

--- a/spec/classes/jira_install_staging_spec.rb
+++ b/spec/classes/jira_install_staging_spec.rb
@@ -12,19 +12,28 @@ describe 'jira' do
         :format      => 'tar.gz',
         :product     => 'jira',
         :version     => '6.4.3a',
-        :downloadURL => 'http://www.atlassian.com/software/jira/downloads/binary/',
-        }}
+        :downloadURL => 'http://www.atlassian.com/software/jira/downloads/binary',
+      }}
       it { should contain_group('jira') }
       it { should contain_user('jira').with_shell('/bin/true') }
       it 'should deploy jira 6.4.3a from tar.gz' do
-        should contain_deploy__file("atlassian-jira-6.4.3a.tar.gz")
+        should contain_staging__file("atlassian-jira-6.4.3a.tar.gz").with({
+          'source' => 'http://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-6.4.3a.tar.gz',
+          })
+        should contain_staging__extract("atlassian-jira-6.4.3a.tar.gz").with({
+          'target' => '/opt/jira/atlassian-jira-6.4.3a-standalone',
+          'creates' => '/opt/jira/atlassian-jira-6.4.3a-standalone/conf',
+          'strip'   => '1',
+          'user'    => 'jira',
+          'group'   => 'jira',
+          })
       end
       it 'should manage the jira home directory' do
         should contain_file('/home/jira').with({
           'ensure' => 'directory',
           'owner' => 'jira',
           'group' => 'jira'
-          })
+        })
       end
     end
 
@@ -39,8 +48,8 @@ describe 'jira' do
         :group => 'bar',
         :uid   => 333,
         :gid   => 444,
-        :downloadURL => 'http://downloads.atlassian.com/',
-        }}
+        :downloadURL => 'http://downloads.atlassian.com',
+      }}
   
       it { should contain_user('foo').with({
           'home'  => '/random/homedir',
@@ -51,11 +60,16 @@ describe 'jira' do
       it { should contain_group('bar') }
   
       it 'should deploy jira 6.0.0 from tar.gz' do
-        should contain_deploy__file("atlassian-jira-6.0.0.tar.gz").with({
-          'url' => 'http://downloads.atlassian.com/',
-          'owner' => 'foo',
-          'group' => 'bar'
-          })
+        should contain_staging__file("atlassian-jira-6.0.0.tar.gz").with({
+          'source' => 'http://downloads.atlassian.com/atlassian-jira-6.0.0.tar.gz',
+        })
+        should contain_staging__extract("atlassian-jira-6.0.0.tar.gz").with({
+          'target' => '/opt/jira/atlassian-jira-6.0.0-standalone',
+          'creates' => '/opt/jira/atlassian-jira-6.0.0-standalone/conf',
+          'strip'   => '1',
+          'user'    => 'foo',
+          'group'   => 'bar',
+        })
       end
   
       it 'should manage the jira home directory' do


### PR DESCRIPTION
nanlui-staging is a puppet approved module, it makes sense to support it
and make it the default.
- puppet-staging is now the default module for deploying the jira binaries
- puppet-deploy is still available with the parameter:
  staging_or_deploy => 'deploy'
- Add tests for nanlui-staging module
