### PR TITLE
Add new parameter: jvm_permgen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##2014-10-19 - Release 1.1.2
+- Add new parameter: jvm_permgen, defaults to 256m.
+- Updates to readme
+
 ##2014-10-11 - Release 1.1.1
 - Fix typo of in module nanliu-staging, preving module from being installed
 

--- a/README.md
+++ b/README.md
@@ -68,13 +68,14 @@ A complete example with postgres/nginx/JIRA is available [here](https://github.c
 
 ######Upgrades to JIRA
 
-Jira can be upgraded by incrementing this version number. This will *STOP* the running instance of Jira and attempt to upgrade. You should take caution when doing large version upgrades. Always backup your database and your home directory.
+Jira can be upgraded by incrementing this version number. This will *STOP* the running instance of Jira and attempt to upgrade. You should take caution when doing large version upgrades. Always backup your database and your home directory. The jira::facts class is required for upgrades.
 
 ```puppet
   class { 'jira':
     javahome    => '/opt/java',
     version     => '6.3.7',
   }
+  class { 'jira::facts': }
 ```
 
 ######Upgrades to the JIRA puppet Module
@@ -85,7 +86,6 @@ mkrakowitzer-deploy has been replaced with nanliu-staging as the default module 
     javahome    => '/opt/java',
     staging_or_deploy => 'deploy',
   }
-  class { 'jira::facts': }
 ```
 
 ##Reference
@@ -237,11 +237,18 @@ The JAVA_HOME directory, defaults to undef. This is a *required* parameter
 
 #####`$jvm_xms`
 
+The initial memory allocation pool for a Java Virtual Machine.
 defaults to '256m'
 
 #####`$jvm_xmx`
 
+Maximum memory allocation pool for a Java Virtual Machine.
 defaults to '1024m'
+
+#####`$jvm_permgen`
+
+Increase max permgen size for a Java Virtual Machine.
+defaults to '256m'
 
 #####`$jvm_optional`
 
@@ -399,9 +406,11 @@ Using [Beaker - Puppet Labs cloud enabled acceptance testing tool.](https://gith
 
 run (Additional yak shaving may be required):
 
+```
 BEAKER_set=ubuntu-server-12042-x64 bundle exec rake beaker
 BEAKER_set==debian-73-x64 bundle exec rake beaker
 BEAKER_set==centos-64-x64 bundle exec rake beaker
+```
 
 ##Contributors
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,6 +91,7 @@ class jira (
   $javahome,
   $jvm_xms      = '256m',
   $jvm_xmx      = '1024m',
+  $jvm_permgen  = '256m',
   $jvm_optional = '-XX:-HeapDumpOnOutOfMemoryError',
   $java_opts    = '',
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "mkrakowitzer-jira",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "brycejohnson",
   "summary": "Module to install Jira",
   "license": "Apache License, Version 2.0",

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -18,6 +18,7 @@ JVM_SUPPORT_RECOMMENDED_ARGS="<%= scope.lookupvar('jira::jvm_optional') %>"
 #
 JVM_MINIMUM_MEMORY="<%= scope.lookupvar('jira::jvm_xms') %>"
 JVM_MAXIMUM_MEMORY="<%= scope.lookupvar('jira::jvm_xmx') %>"
+JVM_PERMGEN_MEMORY="<%= scope.lookupvar('jira::jvm_permgen') %>"
 
 #
 # The following are the required arguments for JIRA.
@@ -60,7 +61,7 @@ fi
 JAVA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} ${JAVA_OPTS} ${JVM_REQUIRED_ARGS} ${DISABLE_NOTIFICATIONS} ${JVM_SUPPORT_RECOMMENDED_ARGS} ${JVM_EXTRA_ARGS} ${JIRA_HOME_MINUSD}"
 
 # Perm Gen size needs to be increased if encountering OutOfMemoryError: PermGen problems. Specifying PermGen size is not valid on IBM JDKs
-JIRA_MAX_PERM_SIZE=256m
+JIRA_MAX_PERM_SIZE=${JVM_PERMGEN_MEMORY}
 if [ -f "${PRGDIR}/permgen.sh" ]; then
     echo "Detecting JVM PermGen support..."
     . "${PRGDIR}/permgen.sh"


### PR DESCRIPTION
jvm_permgen
 Increase max permgen size for a Java Virtual Machine. Default: '256m'
