### PR TITLE
Parameterize the lockfile variable in the init script

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,11 +8,19 @@ class jira::params {
       $json_packages         = 'rubygem-json'
       $service_file_location = '/usr/lib/systemd/system/jira.service'
       $service_file_template = 'jira/jira.service.erb'
+      $service_lockfile      = '/var/lock/subsys/jira'
+    }
+    /Debian/: {
+      $json_packages         = [ 'rubygem-json', 'ruby-json' ]
+      $service_file_location = '/etc/init.d/jira'
+      $service_file_template = 'jira/jira.initscript.erb'
+      $service_lockfile      = '/var/lock/jira'
     }
     default: {
       $json_packages         = [ 'rubygem-json', 'ruby-json' ]
       $service_file_location = '/etc/init.d/jira'
       $service_file_template = 'jira/jira.initscript.erb'
+      $service_lockfile      = '/var/lock/subsys/jira'
     }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -20,6 +20,7 @@ class jira::service(
   $service_enable        = $jira::service_enable,
   $service_file_location = $jira::params::service_file_location,
   $service_file_template = $jira::params::service_file_template,
+  $service_lockfile      = $jira::params::service_lockfile,
 
 ) inherits jira::params {
   

--- a/templates/jira.initscript.erb
+++ b/templates/jira.initscript.erb
@@ -28,12 +28,7 @@
 ### END INIT INFO
 ACTION=$1
 SERVICE=jira
-OS=`facter osfamily`
-lockfile=/var/lock/subsys/$SERVICE
-if [ $OS == "Debian" ]; then
-  lockfile=/var/lock/$SERVICE
-fi
-
+lockfile=<%= @service_lockfile %>
 export JAVA_HOME=<%= scope.lookupvar('jira::javahome') %>
 export CATALINA_HOME=<%= scope.lookupvar('jira::webappdir') %>
 


### PR DESCRIPTION
The main reason for this is that "facter" isn't in the $PATH for root if you use
Puppet Enterprise, since PE is installed in /opt/puppet/ by default. Hence, the
init script will give an error if you run it with PE installed.
