### PR TITLE
Parameterize the jira::dburl variable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,7 @@ class jira (
   $dbport                  = '5432',
   $dbdriver                = 'org.postgresql.Driver',
   $dbtype                  = 'postgres72',
+  $dburl                   = undef,
   $poolsize                = '20',
   $mysql_connector_package = $jira::params::mysql_connector_package,
   $mysql_connector_jar     = $jira::params::mysql_connector_jar,
@@ -118,7 +119,15 @@ class jira (
   }
 
   $webappdir    = "${installdir}/atlassian-${product}-${version}-standalone"
-  $dburl        = "jdbc:${db}://${dbserver}:${dbport}/${dbname}"
+  if $dburl {
+    $dburl_real = $dburl
+  }
+  else {
+    $dburl_real = $db ? {
+      'postgresql' => "jdbc:${db}://${dbserver}:${dbport}/${dbname}",
+      'mysql'      => "jdbc:${db}://${dbserver}:${dbport}/${dbname}?useUnicode=true&amp;characterEncoding=UTF8&amp;sessionVariables=storage_engine=InnoDB",
+    }
+  }
 
   anchor { 'jira::start':
   } ->

--- a/templates/dbconfig.mysql.xml.erb
+++ b/templates/dbconfig.mysql.xml.erb
@@ -5,7 +5,7 @@
   <delegator-name>default</delegator-name>
   <database-type>mysql</database-type>
   <jdbc-datasource>
-    <url><%= scope.lookupvar('jira::dburl') %>?useUnicode=true&amp;characterEncoding=UTF8&amp;sessionVariables=storage_engine=InnoDB</url>
+    <url><%= scope.lookupvar('jira::dburl_real') %></url>
     <driver-class><%= scope.lookupvar('jira::dbdriver') %></driver-class>
     <username><%= scope.lookupvar('jira::dbuser') %></username>
     <password><%= scope.lookupvar('jira::dbpassword') %></password>

--- a/templates/dbconfig.postgresql.xml.erb
+++ b/templates/dbconfig.postgresql.xml.erb
@@ -6,7 +6,7 @@
   <database-type><%= scope.lookupvar('jira::dbtype') %></database-type>
   <schema-name>public</schema-name>
   <jdbc-datasource>
-    <url><%= scope.lookupvar('jira::dburl') %></url>
+    <url><%= scope.lookupvar('jira::dburl_real') %></url>
     <driver-class><%= scope.lookupvar('jira::dbdriver') %></driver-class>
     <username><%= scope.lookupvar('jira::dbuser') %></username>
     <password><%= scope.lookupvar('jira::dbpassword') %></password>


### PR DESCRIPTION
This is so $dburl can be overriden as a workaround for the following bug in Mysql Connector/J 5.1.16:
https://confluence.atlassian.com/display/JIRAKB/%27NullPointerException+at+com.mysql.jdbc.ConnectionImpl.getServerCharacterEncoding%27+Error+When+Using+MySQL+Driver+v5.1.16

Specifically, I've found that setting jira::dburl to "'jdbc:mysql://127.0.0.1:3305/jira?useUnicode=true&amp;characterEncoding=UTF8" works.
