### PR TITLE
Service status is not working when using init scripts

### DIFF
--- a/templates/jira.initscript.erb
+++ b/templates/jira.initscript.erb
@@ -62,24 +62,18 @@ function start() {
 
 function status() {
 
-  STATUS=$( ps aux | grep "[c]atalina.base=$CATALINA_HOME" | wc -l )
-  if [ $STATUS -gt 0 ];then
-    RETVAL=`ps -ef |grep $SERVICE |grep -v grep |grep atlassian-jira |grep ^<%= scope.lookupvar('jira::user')%> |wc -l`
-    if [ $RETVAL -ne 0 ];then
-      echo "$SERVICE is running"
-      return 0
-    else
-      echo "$SERVICE is stopped"
-      return 1
-    fi
-  else
-    echo "$SERVICE is stopped"
-    return 1
+STATUS=$( pgrep -u <%= scope.lookupvar('jira::user')%> -f atlassian-jira ) || STATUS=0
+ if [ $STATUS -ne 0 ];then
+   echo "$SERVICE is running"
+   return 0
+ else
+   echo "$SERVICE is stopped"
+   return 1
  fi
   
 }
 
-function execute() {
+fuction execute() {
   case "$ACTION" in
     start)
       start

--- a/templates/jira.initscript.erb
+++ b/templates/jira.initscript.erb
@@ -73,7 +73,7 @@ STATUS=$( pgrep -u <%= scope.lookupvar('jira::user')%> -f atlassian-jira ) || ST
   
 }
 
-fuction execute() {
+function execute() {
   case "$ACTION" in
     start)
       start

--- a/templates/jira.initscript.erb
+++ b/templates/jira.initscript.erb
@@ -64,14 +64,13 @@ function status() {
 
   STATUS=$( ps aux | grep "[c]atalina.base=$CATALINA_HOME" | wc -l )
   if [ $STATUS -gt 0 ];then
-    ps -ef |grep $SERVICE |grep -v grep |awk '{ print $2 }' | <%= scope.lookupvar('jira::javahome') %>/bin/jps |grep -v Jps |grep -v grep > /dev/null
-    RETVAL=$?
-    if [ $RETVAL -eq 0 ];then
+    RETVAL=`ps -ef |grep $SERVICE |grep -v grep |grep atlassian-jira |grep ^<%= scope.lookupvar('jira::user')%> |wc -l`
+    if [ $RETVAL -ne 0 ];then
       echo "$SERVICE is running"
-      return $RETVAL
+      return 0
     else
       echo "$SERVICE is stopped"
-      return $RETVAL
+      return 1
     fi
   else
     echo "$SERVICE is stopped"


### PR DESCRIPTION
Turns out that the check for the status of the jira server was always returning a state of 'stopped'

This was due to the jps task always having an exit status of 1 even thou the jira service was running.
 have chaged this to simply look for a process owened by the jira user