### PR TITLE
Systemd support for debian 8 jessie

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,30 +8,42 @@ class jira::params {
 
   case $::osfamily {
     /RedHat/: {
-      if $::operatingsystemmajrelease == '7' {
+      if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
         $json_packages           = 'rubygem-json'
         $service_file_location   = '/usr/lib/systemd/system/jira.service'
         $service_file_template   = 'jira/jira.service.erb'
         $service_lockfile        = '/var/lock/subsys/jira'
-      } elsif $::operatingsystemmajrelease == '6' or $::operatingsystem == 'Amazon'{
+        $service_provider        = 'systemd'
+      } elsif versioncmp($::operatingsystemmajrelease, '6') >= 0 or $::operatingsystem == 'Amazon'{
         $json_packages           = [ 'rubygem-json', 'ruby-json' ]
         $service_file_location   = '/etc/init.d/jira'
         $service_file_template   = 'jira/jira.initscript.erb'
         $service_lockfile        = '/var/lock/subsys/jira'
+        $service_provider        = undef
       } else {
         fail("\"${module_name}\" provides no service parameters
             for \"${::osfamily}\" - \"${::operatingsystemmajrelease}\"")
       }
     } /Debian/: {
+      if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
+        $json_packages           = 'ruby-json'
+        $service_file_location   = '/lib/systemd/system/jira.service'
+        $service_file_template   = 'jira/jira.service.erb'
+        $service_lockfile        = '/var/lock/subsys/jira'
+        $service_provider        = 'systemd'
+      } else {
         $json_packages           = [ 'rubygem-json', 'ruby-json' ]
         $service_file_location   = '/etc/init.d/jira'
         $service_file_template   = 'jira/jira.initscript.erb'
         $service_lockfile        = '/var/lock/jira'
+        $service_provider        = 'debian'
+      }
     } default: {
         $json_packages           = [ 'rubygem-json', 'ruby-json' ]
         $service_file_location   = '/etc/init.d/jira'
         $service_file_template   = 'jira/jira.initscript.erb'
         $service_lockfile        = '/var/lock/subsys/jira'
+        $service_provider        = undef
     }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -23,6 +23,7 @@ class jira::service(
   $service_file_location = $jira::params::service_file_location,
   $service_file_template = $jira::params::service_file_template,
   $service_lockfile      = $jira::params::service_lockfile,
+  $service_provider      = $jira::params::service_provider,
 
 ) inherits jira::params {
   
@@ -38,7 +39,7 @@ class jira::service(
     validate_string($service_ensure)
     validate_bool($service_enable)
 
-    if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7' {
+    if $service_provider == 'systemd' {
       exec { 'refresh_systemd':
         command     => 'systemctl daemon-reload',
         refreshonly => true,
@@ -53,6 +54,7 @@ class jira::service(
       require   => File[$service_file_location],
       notify    => $service_notify,
       subscribe => $service_subscribe,
+      provider  => $service_provider,
     }
   }
 }


### PR DESCRIPTION
On Debian Jessie can use systemd units instead Init.d-scripts.
When I try use old init.d scheme with jira, i have error because puppet can't use 'service' command for control init.d based services on Jessie.

I try to use jira systemd unit without any changes and its work fine.