### PR TITLE
adding ability to change tomcatShutdownPort

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -114,6 +114,7 @@ class jira (
   # Tomcat
   $tomcatAddress               = undef,
   $tomcatPort                  = 8080,
+  $tomcatShutdownPort          = 8005,
   $tomcatMaxHttpHeaderSize     = '8192',
   $tomcatMinSpareThreads       = '25',
   $tomcatConnectionTimeout     = '20000',

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -27,7 +27,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<Server port="8005" shutdown="SHUTDOWN">
+<Server port="<%= @tomcatShutdownPort %>" shutdown="SHUTDOWN">
 
     <!--APR library loader. Documentation at /docs/apr.html -->
     <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />


### PR DESCRIPTION
When JIRA is ran on a server with existing tomcat instance, the shutdown port conflicts (hardcoded to 8005). This PR adds a param to init.pp to override the default.