### PR TITLE
Pe 431 facts

### DIFF
--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -29,7 +29,7 @@ class jira::facts (
   if $::puppetversion =~ /Puppet Enterprise/ {
     $ruby_bin = '/opt/puppet/bin/ruby'
     $dir = 'puppetlabs/'
-  } elsif $::values::aio_agent_version =~ /1\.3\.*[0-9]*/ {
+  } elsif $::aio_agent_version =~ /1\.3\.*[0-9]*/ {
     $ruby_bin = '/opt/puppetlabs/puppet/bin/ruby'
     $dir = 'puppetlabs/'
   } else {
@@ -46,7 +46,7 @@ class jira::facts (
   }
 
   # Install $json_packages only if osfamily is RedHat and agent is version PE 3.8 or less or not an AIO version 1.3.x
-  if $::osfamily == 'RedHat' and (($::puppetversion !~ /Puppet Enterprise/) or ($::values::aio_agent_version !~ /1\.3\.*[0-9]*/)) {
+  if $::osfamily == 'RedHat' and (($::puppetversion !~ /Puppet Enterprise/) or ($::aio_agent_version !~ /1\.3\.*[0-9]*/)) {
     package { $json_packages: ensure => present, }
   }
 

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -14,7 +14,7 @@
 #
 # class { 'jira::facts': }
 #
-class jira::facts(
+class jira::facts (
   $ensure        = 'present',
   $port          = $jira::tomcatPort,
   $uri           = $jira::tomcatAddress ? {
@@ -22,34 +22,30 @@ class jira::facts(
     default => $jira::tomcatAddress,
   },
   $contextpath   = $jira::contextpath,
-  $json_packages = $jira::params::json_packages,
-) inherits jira::params {
-
+  $json_packages = $jira::params::json_packages,) inherits jira::params {
   # Puppet Enterprise supplies its own ruby version if your using it.
   # A modern ruby version is required to run the executable fact
   if $::puppetversion =~ /Puppet Enterprise/ {
     $ruby_bin = '/opt/puppet/bin/ruby'
-    $dir      = 'puppetlabs/'
+    $dir = 'puppetlabs/'
+  } elsif $::pe_version =~ /2015\.3\.*[0-9]*/ {
+    $ruby_bin = '/opt/puppetlabs/puppet/bin'
+    $dir = 'puppetlabs/'
   } else {
     $ruby_bin = '/usr/bin/env ruby'
-    $dir      = ''
+    $dir = ''
   }
 
-  if ! defined(File["/etc/${dir}facter"]) {
-    file { "/etc/${dir}facter":
-      ensure  => directory,
-    }
-  }
-  if ! defined(File["/etc/${dir}facter/facts.d"]) {
-    file { "/etc/${dir}facter/facts.d":
-      ensure  => directory,
-    }
+  if !defined(File["/etc/${dir}facter"]) {
+    file { "/etc/${dir}facter": ensure => directory, }
   }
 
-  if $::osfamily == 'RedHat' and $::puppetversion !~ /Puppet Enterprise/ {
-    package { $json_packages:
-      ensure => present,
-    }
+  if !defined(File["/etc/${dir}facter/facts.d"]) {
+    file { "/etc/${dir}facter/facts.d": ensure => directory, }
+  }
+
+  if $::osfamily == 'RedHat' and $::puppetversion !~ /Puppet Enterprise|2015\.3\.*[0-9]*/ {
+    package { $json_packages: ensure => present, }
   }
 
   file { "/etc/${dir}facter/facts.d/jira_facts.rb":

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -28,7 +28,7 @@ class jira::facts (
   if $::puppetversion =~ /Puppet Enterprise/ {
     $ruby_bin = '/opt/puppet/bin/ruby'
     $dir = 'puppetlabs/'
-  } elsif $::pe_version =~ /2015\.3\.*[0-9]*/ {
+  } elsif $::puppetversion =~ /4\.3\.*[0-9]*/ {
     $ruby_bin = '/opt/puppetlabs/puppet/bin'
     $dir = 'puppetlabs/'
   } else {
@@ -44,7 +44,7 @@ class jira::facts (
     file { "/etc/${dir}facter/facts.d": ensure => directory, }
   }
 
-  if $::osfamily == 'RedHat' and $::puppetversion !~ /Puppet Enterprise|2015\.3\.*[0-9]*/ {
+  if $::osfamily == 'RedHat' and $::puppetversion !~ /Puppet Enterprise|4\.3\.*[0-9]*/ {
     package { $json_packages: ensure => present, }
   }
 

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -29,7 +29,7 @@ class jira::facts (
     $ruby_bin = '/opt/puppet/bin/ruby'
     $dir = 'puppetlabs/'
   } elsif $::puppetversion =~ /4\.3\.*[0-9]*/ {
-    $ruby_bin = '/opt/puppetlabs/puppet/bin'
+    $ruby_bin = '/opt/puppetlabs/puppet/bin/ruby'
     $dir = 'puppetlabs/'
   } else {
     $ruby_bin = '/usr/bin/env ruby'

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -25,10 +25,11 @@ class jira::facts (
   $json_packages = $jira::params::json_packages,) inherits jira::params {
   # Puppet Enterprise supplies its own ruby version if your using it.
   # A modern ruby version is required to run the executable fact
+  # Since PE 2015.2 the agents are All in One (AIO) wich also include it's own ruby version
   if $::puppetversion =~ /Puppet Enterprise/ {
     $ruby_bin = '/opt/puppet/bin/ruby'
     $dir = 'puppetlabs/'
-  } elsif $::puppetversion =~ /4\.3\.*[0-9]*/ {
+  } elsif $::values::aio_agent_version =~ /1\.3\.*[0-9]*/ {
     $ruby_bin = '/opt/puppetlabs/puppet/bin/ruby'
     $dir = 'puppetlabs/'
   } else {
@@ -44,7 +45,8 @@ class jira::facts (
     file { "/etc/${dir}facter/facts.d": ensure => directory, }
   }
 
-  if $::osfamily == 'RedHat' and $::puppetversion !~ /Puppet Enterprise|4\.3\.*[0-9]*/ {
+  # Install $json_packages only if osfamily is RedHat and agent is version PE 3.8 or less or not an AIO version 1.3.x
+  if $::osfamily == 'RedHat' and (($::puppetversion !~ /Puppet Enterprise/) or ($::values::aio_agent_version !~ /1\.3\.*[0-9]*/)) {
     package { $json_packages: ensure => present, }
   }
 

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -45,8 +45,8 @@ class jira::facts (
     file { "/etc/${dir}facter/facts.d": ensure => directory, }
   }
 
-  # Install $json_packages only if osfamily is RedHat and agent is version PE 3.8 or less or not an AIO version 1.3.x
-  if $::osfamily == 'RedHat' and (($::puppetversion !~ /Puppet Enterprise/) or ($::aio_agent_version !~ /1\.3\.*[0-9]*/)) {
+  # Install $json_packages only if osfamily is RedHat and agent is version PE 3.8 and less or not an AIO version 1.3.x
+  if $::osfamily == 'RedHat' and (($::puppetversion !~ /Puppet Enterprise/) and ($::aio_agent_version !~ /1\.3\.*[0-9]*/)) {
     package { $json_packages: ensure => present, }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">=3.7.0 <4.0.0"
+      "version_requirement": ">=3.0.0 <=4.3.1"
     },
     {
       "name": "puppet",


### PR DESCRIPTION
Since upgrading to 2015.3 the jira_fact is in error because $::puppetversion is not reporting that it's running Puppet Enterprise.

I've created a patch that is looking at the agent version 4.3.x and point the ruby interpreter at the default location for 2015.3.x
Also I've updated the condition to not try to install the json packages under Redhat when using the puppet agent 4.3.x that is used in 2015.3.x