### PR TITLE
Ubuntu initd

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,18 +25,28 @@ class jira::params {
             for \"${::osfamily}\" - \"${::operatingsystemmajrelease}\"")
       }
     } /Debian/: {
-      if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
-        $json_packages           = 'ruby-json'
-        $service_file_location   = '/lib/systemd/system/jira.service'
-        $service_file_template   = 'jira/jira.service.erb'
-        $service_lockfile        = '/var/lock/subsys/jira'
-        $service_provider        = 'systemd'
-      } else {
-        $json_packages           = [ 'rubygem-json', 'ruby-json' ]
-        $service_file_location   = '/etc/init.d/jira'
-        $service_file_template   = 'jira/jira.initscript.erb'
-        $service_lockfile        = '/var/lock/jira'
-        $service_provider        = 'debian'
+      case $::operatingsystem {
+        'Ubuntu': {
+          $json_packages           = [ 'rubygem-json', 'ruby-json' ]
+          $service_file_location   = '/etc/init.d/jira'
+          $service_file_template   = 'jira/jira.initscript.erb'
+          $service_lockfile        = '/var/lock/jira'
+          $service_provider        = 'debian'
+        } default: {
+          if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
+            $json_packages           = 'ruby-json'
+            $service_file_location   = '/lib/systemd/system/jira.service'
+            $service_file_template   = 'jira/jira.service.erb'
+            $service_lockfile        = '/var/lock/subsys/jira'
+            $service_provider        = 'systemd'
+          } else {
+            $json_packages           = [ 'rubygem-json', 'ruby-json' ]
+            $service_file_location   = '/etc/init.d/jira'
+            $service_file_template   = 'jira/jira.initscript.erb'
+            $service_lockfile        = '/var/lock/jira'
+            $service_provider        = 'debian'
+          }
+        }
       }
     } default: {
         $json_packages           = [ 'rubygem-json', 'ruby-json' ]

--- a/spec/classes/jira_service_spec.rb
+++ b/spec/classes/jira_service_spec.rb
@@ -36,6 +36,14 @@ describe 'jira::service' do
             .with_content(/\/var\/lock\/jira/) }
         end
         end
+        if os =~ /ubuntu/
+          context 'default params' do
+            let(:params) {{
+              :javahome => '/opt/java'
+            }}
+            it { should_not contain_file('/lib/systemd/system/jira.service') }
+          end
+        end
         context 'overwriting service_manage param' do
           let(:params) {{
             :service_manage => false,


### PR DESCRIPTION
Fix to https://github.com/voxpupuli/puppet-jira/issues/122. Check that the Debian-variant is not Ubuntu before opting to use systemd rather than initd.