### PR TITLE
Add crowd single sign-on functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Enables or disables clustering, defaults to false
 
 #####`$shared_homedir`
 
-The directory of the shared home directory, defaults to undef. When clustering is enabled, this parameter is *required*. 
+The directory of the shared home directory, defaults to undef. When clustering is enabled, this parameter is *required*.
 
 ####database parameters####
 
@@ -400,6 +400,28 @@ Password to access java keystore. Defaults to 'changeit'
 #####`$tomcatKeystoreType`
 
 Defaults to 'JKS'. Valid options are 'JKS', 'PKCS12', 'JCEKS'.
+
+####Crowd single sign on parameters####
+####`enable_sso`
+Enable crowd single sign on configuration as described in https://confluence.atlassian.com/display/CROWD/Integrating+Crowd+with+Atlassian+Confluence#IntegratingCrowdwithAtlassianConfluence-2.2EnableSSOintegrationwithCrowd(Optional)
+####`application_name`
+Set crowd application name
+####`application_password`
+Set crowd application password
+####`application_login_url`
+Set crowd application login url, where to login into crowd (e.g. https://crowd.example.com/console/)
+####`crowd_server_url`
+Set crowd application services url, e.g. https://crowd.example.com/services/
+####`crowd_base_url`
+Set crowd base url, e.g. https://crowd.example.com/
+####`session_isauthenticated`
+Some more crowd.properties for SSO, see atlassian documentation for details
+####`session_tokenkey`
+Some more crowd.properties for SSO, see atlassian documentation for details
+####`session_validationinterval`
+Some more crowd.properties for SSO, see atlassian documentation for details
+####`session_lastvalidation`
+Some more crowd.properties for SSO, see atlassian documentation for details
 
 ##Usage
 

--- a/files/seraph-config_withSSO.xml
+++ b/files/seraph-config_withSSO.xml
@@ -1,0 +1,122 @@
+<security-config>
+    <parameters>
+        <init-param>
+            <!--
+              The login URL to redirect to when the user tries to access a protected resource (rather than clicking on
+              an explicit login link). Most of the time, this will be the same value as 'link.login.url'.
+                - if the URL is absolute (contains '://'), then redirect that URL (for SSO applications)
+                - else the context path will be prepended to this URL
+
+                If '${originalurl}' is present in the URL, it will be replaced with the URL that the user requested.
+                This gives SSO login pages the chance to redirect to the original page
+
+                '${pageCaps}' should be supported accordingly to com.atlassian.sal.api.page.PageCapability
+
+                '${userRole}' when specified, should cause logout after login to an user with privileges lesser than requested
+            -->
+            <param-name>login.url</param-name>
+            <param-value>/login.jsp?permissionViolation=true&amp;os_destination=${originalurl}&amp;page_caps=${pageCaps}&amp;user_role=${userRole}</param-value>
+            <!--<param-value>http://sso.mycompany.com/login?redirectTo=${originalurl}</param-value>-->
+        </init-param>
+        <init-param>
+            <!--
+              the URL to redirect to when the user explicitly clicks on a login link (rather than being redirected after
+              trying to access a protected resource). Most of the time, this will be the same value as 'login.url'.
+                - same properties as login.url above
+            -->
+            <param-name>link.login.url</param-name>
+            <param-value>/login.jsp?os_destination=${originalurl}</param-value>
+            <!--<param-value>/secure/Dashboard.jspa?os_destination=${originalurl}</param-value>-->
+            <!--<param-value>http://sso.mycompany.com/login?redirectTo=${originalurl}</param-value>-->
+        </init-param>
+        <init-param>
+            <!-- URL for logging out.
+                 - If relative, Seraph just redirects to this URL, which is responsible for calling Authenticator.logout().
+                 - If absolute (eg. SSO applications), Seraph calls Authenticator.logout() and redirects to the URL
+                 -->
+            <param-name>logout.url</param-name>
+            <param-value>/secure/Logout!default.jspa</param-value>
+            <!--<param-value>http://sso.mycompany.com/logout</param-value>-->
+        </init-param>
+        <!--
+          The path to *forward* to when the user tries to POST to a protected resource (rather than clicking on
+          an explicit login link). Note that this is done using a servlet FORWARD, not a redirect. Information
+          about the original request can be gotten from the javax.servlet.forward.* request attributes.
+
+          At this point you will probably want to save the user's POST params so he can log in again and retry
+          the POST.
+
+          Defaults to undefined, in which case Seraph will just do a redirect instead of a FORWARD.
+        -->
+        <init-param>
+            <param-name>login.forward.path</param-name>
+            <param-value>/secure/XsrfErrorAction.jspa</param-value>
+        </init-param>
+        <!-- The key that the original URL is stored with in the session -->
+        <init-param>
+            <param-name>original.url.key</param-name>
+            <param-value>os_security_originalurl</param-value>
+        </init-param>
+        <init-param>
+            <param-name>login.cookie.key</param-name>
+            <param-value>seraph.rememberme.cookie</param-value>
+        </init-param>
+        <!-- This property sets the default remember me cookie max age in seconds.  It is currently set to 2 weeks -->
+        <init-param>
+            <param-name>autologin.cookie.age</param-name>
+            <param-value>1209600</param-value>
+        </init-param>
+        <!-- Basic Authentication can be enabled by passing the authentication type as a configurable url parameter.
+        With this example, you will need to pass http://mycompany.com/anypage?os_authType=basic in the url to enable Basic Authentication -->
+        <init-param>
+            <param-name>authentication.type</param-name>
+            <param-value>os_authType</param-value>
+        </init-param>
+        <!--  If this parameter is set to true, the cookie will never be set secure.  This is useful if you're logging
+              into JIRA via https, but want to browse JIRA over http.  This flag will ensure that the remember me option
+              works correctly.
+        <init-param>
+            <param-name>insecure.cookie</param-name>
+            <param-value>true</param-value>
+        </init-param> -->
+
+        <init-param>
+            <param-name>invalidate.session.on.login</param-name>
+            <param-value>true</param-value>
+        </init-param>
+        <init-param>
+            <param-name>invalidate.session.exclude.list</param-name>
+            <param-value>ASESSIONID,jira.websudo.timestamp,jira.user.project.admin</param-value>
+        </init-param>
+    </parameters>
+
+    <!-- CROWD:START - If enabling Crowd SSO integration uncomment the following SSOSeraphAuthenticator and comment out the JiraSeraphAuthenticator below -->
+    <authenticator class="com.atlassian.jira.security.login.SSOSeraphAuthenticator"/> 
+    <!-- CROWD:END -->
+
+    <!-- CROWD:START - The authenticator below here will need to be commented out for Crowd SSO integration -->
+<!--    <authenticator class="com.atlassian.jira.security.login.JiraSeraphAuthenticator"/>  -->
+    <!-- CROWD:END -->
+
+    <!-- NB: the URL to redirect to is now specified by login.url above -->
+    <services>
+        <service class="com.atlassian.jira.security.JiraPathService" />
+
+        <service class="com.atlassian.seraph.service.WebworkService">
+            <init-param>
+                <param-name>action.extension</param-name>
+                <param-value>jspa</param-value>
+            </init-param>
+        </service>
+
+        <service class="com.atlassian.jira.plugin.webwork.JiraSeraphSecurityService" />
+    </services>
+    
+    <rolemapper class="com.atlassian.jira.security.JiraRoleMapper"/>
+
+    <elevatedsecurityguard class="com.atlassian.jira.security.login.JiraElevatedSecurityGuard"/>
+
+    <interceptors>
+        <interceptor class="com.atlassian.jira.web.filters.JiraLoginInterceptor" />
+    </interceptors>
+</security-config>

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -145,6 +145,19 @@ class jira (
   # Resources for context.xml
   $resources = {},
 
+  # Enable SingleSignOn via Crowd
+
+  $enable_sso = false,
+  $application_name = 'crowd',
+  $application_password = '1234',
+  $application_login_url = 'https://crowd.example.com/console/',
+  $crowd_server_url = 'https://crowd.example.com/services/',
+  $crowd_base_url = 'https://crowd.example.com/',
+  $session_isauthenticated = 'session.isauthenticated',
+  $session_tokenkey = 'session.tokenkey',
+  $session_validationinterval = 5,
+  $session_lastvalidation = 'session.lastvalidation',
+
 ) inherits jira::params {
 
   # Parameter validations
@@ -215,4 +228,8 @@ class jira (
   } ->
   anchor { 'jira::end': }
 
+  if ($enable_sso) {
+    class { 'jira::sso':
+    }
+  }
 }

--- a/manifests/sso.pp
+++ b/manifests/sso.pp
@@ -1,0 +1,38 @@
+# == Class: confluence::sso
+#
+# Install confluence SSO via crowd, See README.md for more.
+#
+class jira::sso(
+  $application_name = $::jira::application_name,
+  $application_password = $::jira::application_password,
+  $application_login_url = $::jira::application_login_url,
+  $crowd_server_url = $::jira::crowd_server_url,
+  $crowd_base_url = $::jira::crowd_base_url,
+  $session_isauthenticated = $::jira::session_isauthenticated,
+  $session_tokenkey = $::jira::session_tokenkey,
+  $session_validationinterval = $::jira::session_validationinterval,
+  $session_lastvalidation = $::jira::session_lastvalidation,
+) {
+
+  validate_re($application_login_url,'^https?\://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(/\S*)?$')
+  validate_re($crowd_server_url,'^https?\://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(/\S*)?$')
+  validate_re($crowd_base_url,'^https?\://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(/\S*)?$')
+
+  file { "${jira::webappdir}/atlassian-jira/WEB-INF/classes/crowd.properties":
+    ensure  => present,
+    content => template('jira/crowd.properties'),
+    mode    => '0660',
+    owner   => $::jira::user,
+    group   => $::jira::group,
+    require => Class['jira::install'],
+    notify  => Class['jira::service'],
+  }
+  file { "${jira::webappdir}/atlassian-jira/WEB-INF/classes/seraph-config.xml":
+    source  => 'puppet:///modules/jira/seraph-config_withSSO.xml',
+    mode    => '0660',
+    owner   => $::jira::user,
+    group   => $::jira::group,
+    require => Class['jira::install'],
+    notify  => Class['jira::service'],
+  }
+}

--- a/spec/classes/jira_sso_spec.rb
+++ b/spec/classes/jira_sso_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper.rb'
+
+describe 'jira' do
+  describe 'jira::sso' do
+    context 'default params' do
+      let(:params) {{
+        :javahome   => '/opt/java',
+        :version    => '6.3.4a',
+        :enable_sso => true,
+      }}
+      it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/seraph-config.xml')}
+      it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/crowd.properties')}
+    end
+    context 'with param application_name set to appname' do
+      let(:params) {{
+        :javahome         => '/opt/java',
+        :version          => '6.3.4a',
+        :enable_sso       => true,
+        :application_name => 'appname',
+      }}
+      it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/crowd.properties')
+        .with_content(/application.name                        appname/)
+      }
+    end
+    context 'with param application_login_url set to ERROR' do
+      let(:params) {{
+        :javahome              => '/opt/java',
+        :version               => '6.3.4a',
+        :enable_sso            => true,
+        :application_login_url => 'ERROR',
+      }}
+      it('should fail') {
+        should raise_error(Puppet::Error, /does not match/)
+      }
+    end
+    context 'with non default params' do
+      let(:params) {{
+        :javahome              => '/opt/java',
+        :version               => '6.3.4a',
+        :enable_sso            => true,
+        :application_name      => 'app',
+        :application_password  => 'password',
+        :application_login_url => 'https://login.url/',
+        :crowd_server_url      => 'https://crowd.url/',
+        :crowd_base_url        => 'http://crowdbase.url',
+      }}
+      it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/seraph-config.xml')}
+      it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/crowd.properties')
+        .with_content(/application.name                        app/)
+        .with_content(/application.password                    password/)
+        .with_content(/application.login.url                   https:\/\/login.url\//)
+        .with_content(/crowd.server.url                        https:\/\/crowd.url\//)
+        .with_content(/crowd.base.url                          http:\/\/crowdbase.url/)
+      }
+    end
+  end
+end

--- a/spec/classes/jira_sso_spec.rb
+++ b/spec/classes/jira_sso_spec.rb
@@ -2,56 +2,65 @@ require 'spec_helper.rb'
 
 describe 'jira' do
   describe 'jira::sso' do
-    context 'default params' do
-      let(:params) {{
-        :javahome   => '/opt/java',
-        :version    => '6.3.4a',
-        :enable_sso => true,
-      }}
-      it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/seraph-config.xml')}
-      it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/crowd.properties')}
-    end
-    context 'with param application_name set to appname' do
-      let(:params) {{
-        :javahome         => '/opt/java',
-        :version          => '6.3.4a',
-        :enable_sso       => true,
-        :application_name => 'appname',
-      }}
-      it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/crowd.properties')
-        .with_content(/application.name                        appname/)
-      }
-    end
-    context 'with param application_login_url set to ERROR' do
-      let(:params) {{
-        :javahome              => '/opt/java',
-        :version               => '6.3.4a',
-        :enable_sso            => true,
-        :application_login_url => 'ERROR',
-      }}
-      it('should fail') {
-        should raise_error(Puppet::Error, /does not match/)
-      }
-    end
-    context 'with non default params' do
-      let(:params) {{
-        :javahome              => '/opt/java',
-        :version               => '6.3.4a',
-        :enable_sso            => true,
-        :application_name      => 'app',
-        :application_password  => 'password',
-        :application_login_url => 'https://login.url/',
-        :crowd_server_url      => 'https://crowd.url/',
-        :crowd_base_url        => 'http://crowdbase.url',
-      }}
-      it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/seraph-config.xml')}
-      it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/crowd.properties')
-        .with_content(/application.name                        app/)
-        .with_content(/application.password                    password/)
-        .with_content(/application.login.url                   https:\/\/login.url\//)
-        .with_content(/crowd.server.url                        https:\/\/crowd.url\//)
-        .with_content(/crowd.base.url                          http:\/\/crowdbase.url/)
-      }
+    context 'supported operating systems' do
+      on_supported_os.each do |os, facts|
+        context "on #{os} #{facts}" do
+          let(:facts) do
+            facts
+          end
+          context 'default params' do
+            let(:params) {{
+              :javahome   => '/opt/java',
+              :version    => '6.3.4a',
+              :enable_sso => true,
+            }}
+            it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/seraph-config.xml')}
+            it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/crowd.properties')}
+          end
+          context 'with param application_name set to appname' do
+            let(:params) {{
+              :javahome         => '/opt/java',
+              :version          => '6.3.4a',
+              :enable_sso       => true,
+              :application_name => 'appname',
+            }}
+            it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/crowd.properties')
+              .with_content(/application.name                        appname/)
+            }
+          end
+          context 'with param application_login_url set to ERROR' do
+            let(:params) {{
+              :javahome              => '/opt/java',
+              :version               => '6.3.4a',
+              :enable_sso            => true,
+              :application_login_url => 'ERROR',
+            }}
+            it('should fail') {
+              should raise_error(Puppet::Error, /does not match/)
+            }
+          end
+          context 'with non default params' do
+            let(:params) {{
+              :javahome              => '/opt/java',
+              :version               => '6.3.4a',
+              :enable_sso            => true,
+              :application_name      => 'app',
+              :application_password  => 'password',
+              :application_login_url => 'https://login.url/',
+              :crowd_server_url      => 'https://crowd.url/',
+              :crowd_base_url        => 'http://crowdbase.url',
+            }}
+            it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/seraph-config.xml')}
+            it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/crowd.properties')
+              .with_content(/application.name                        app/)
+              .with_content(/application.password                    password/)
+              .with_content(/application.login.url                   https:\/\/login.url\//)
+              .with_content(/crowd.server.url                        https:\/\/crowd.url\//)
+              .with_content(/crowd.base.url                          http:\/\/crowdbase.url/)
+            }
+          end
+        end
+      end
     end
   end
 end

--- a/templates/crowd.properties
+++ b/templates/crowd.properties
@@ -1,0 +1,11 @@
+application.name                        <%= @application_name %>
+application.password                    <%= @application_password %>
+application.login.url                   <%= @application_login_url %>
+
+crowd.server.url                        <%= @crowd_server_url %>
+crowd.base.url                          <%= @crowd_base_url %>
+
+session.isauthenticated                 <%= @session_isauthenticated %>
+session.tokenkey                        <%= @session_tokenkey %>
+session.validationinterval              <%= @session_validationinterval %>
+session.lastvalidation                  <%= @session_lastvalidation %>


### PR DESCRIPTION
Add crowd's single sign on feature to jira. When using delegated authentication via Atlassian Crowd, you are able to activate this feature according to Atlassian's documentation at https://confluence.atlassian.com/display/CROWD/Integrating+Crowd+with+Atlassian+JIRA#IntegratingCrowdwithAtlassianJIRA-2.2ConfigureJIRAtouseCrowd%27sAuthenticatortoenableSSO%28Optional%29