### PR TITLE
new custom https redirect port

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,10 @@ Enable https/ssl support. Defaults to 'false'. See https://confluence.atlassian.
 
 https/ssl Port to listen on, defaults to 8443.
 
+#####`$tomcat_redirect_https_port`
+
+Specifiy Jira redirect https port when using port redirection 80->8080 and 443->8443 or proxy server in front, defaults to $tomcat_https_port.
+
 #####`$tomcat_key_alias`
 
 The alias name of the java keystore entry. Defaults to 'jira'.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,6 +123,7 @@ class jira (
   $tomcat_enable_lookups            = false,
   $tomcat_native_ssl                = false,
   $tomcat_https_port                = 8443,
+  $tomcat_redirect_https_port       = $tomcat_https_port,
   $tomcat_protocol                  = 'HTTP/1.1',
   $tomcat_use_body_encoding_for_uri = true,
   $tomcat_disable_upload_timeout    = true,

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -59,7 +59,7 @@
                    acceptCount="<%= @tomcat_accept_count %>"
                    disableUploadTimeout="<%= @tomcat_disable_upload_timeout %>"
 <% if @tomcat_native_ssl -%>
-                   redirectPort="<%= @tomcat_https_port %>"
+                   redirectPort="<%= @tomcat_redirect_https_port %>"
 <% end -%>
 <% if @proxy -%>
 <%   @proxy.sort.each do |key,value| -%>


### PR DESCRIPTION
When using a proxy or port redirection, I don't want Jira to add the port 8443 to the url. So I need Jira to redirect to port 443 even if the tomcat https port is 8443 and then I manage the 443 myself to redirect to 8443. Simple change and defaults is the same as before.

In my case: $tomcat_redirect_https_port       =  443