### PR TITLE
New custom https redirect port

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,10 @@ Enable https/ssl support. Defaults to 'false'. See https://confluence.atlassian.
 
 https/ssl Port to listen on, defaults to 8443.
 
+#####`$tomcat_redirect_https_port`
+
+Specifiy Jira redirect https port when using port redirection 80->8080 and 443->8443 or proxy server in front, defaults to $tomcat_https_port. To be used with tomcat_native_ssl.
+
 #####`$tomcat_key_alias`
 
 The alias name of the java keystore entry. Defaults to 'jira'.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -174,11 +174,11 @@ class jira (
   if $datacenter and !$shared_homedir {
     fail("\$shared_homedir must be set when \$datacenter is true")
   }
-  
+
   if $tomcat_redirect_https_port {
-    validate_integer($tomcat_redirects_port)
-    unless ($native_ssl) {
-        fail("You need to set native_ssl to true when using tomcat_redirect_https_port")
+    validate_integer($tomcat_redirect_https_port)
+    unless ($tomcat_native_ssl) {
+        fail('You need to set native_ssl to true when using tomcat_redirect_https_port')
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,6 +123,7 @@ class jira (
   $tomcat_enable_lookups            = false,
   $tomcat_native_ssl                = false,
   $tomcat_https_port                = 8443,
+  $tomcat_redirect_https_port       = undef,
   $tomcat_protocol                  = 'HTTP/1.1',
   $tomcat_use_body_encoding_for_uri = true,
   $tomcat_disable_upload_timeout    = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -174,6 +174,13 @@ class jira (
   if $datacenter and !$shared_homedir {
     fail("\$shared_homedir must be set when \$datacenter is true")
   }
+  
+  if $tomcat_redirect_https_port {
+    validate_integer($tomcat_redirects_port)
+    unless ($native_ssl) {
+        fail("You need to set native_ssl to true when using tomcat_redirect_https_port")
+    }
+  }
 
   # The default Jira product starting with version 7 is 'jira-software'
   if ((versioncmp($version, '7.0.0') > 0) and ($product == 'jira')) {

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -58,8 +58,10 @@
                    useBodyEncodingForURI="<%= @tomcat_use_body_encoding_for_uri %>"
                    acceptCount="<%= @tomcat_accept_count %>"
                    disableUploadTimeout="<%= @tomcat_disable_upload_timeout %>"
-<% if @tomcat_native_ssl -%>
-                   redirectPort="<%= @tomcat_https_port %>"
+<% if @tomcat_native_ssl && @tomcat_redirect_https_port -%>
+                   redirectPort="<%= @tomcat_redirect_https_port %>"
+<% else -%>
+                   redirectPort="<%= @tomcat_https_port%>"
 <% end -%>
 <% if @proxy -%>
 <%   @proxy.sort.each do |key,value| -%>


### PR DESCRIPTION
When using a proxy or port redirection, I don't want Jira to add the port 8443 to the url. So I need Jira to redirect to port 443 even if the tomcat https port is 8443 and then I manage the 443 myself to redirect to 8443. Simple change and defaults is the same as before.

In my case: $tomcat_native_ssl = true and $tomcat_redirect_https_port       =  443

We can discuss how to require native_ssl if redirect_https_port is set?