### PR TITLE
Added hiera support for catalina_opts - useful for configuring jmx as…

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,10 @@ defaults to '-XX:-HeapDumpOnOutOfMemoryError'
 
 defaults to ''
 
+#####`$catalina_opts`
+
+defaults to ''
+
 ####Miscellaneous  parameters####
 
 #####`$download_url`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,6 +93,7 @@ class jira (
   $jvm_permgen  = '256m',
   $jvm_optional = '-XX:-HeapDumpOnOutOfMemoryError',
   $java_opts    = '',
+  $catalina_opts    = '',
 
   # Misc Settings
   $download_url          = 'https://downloads.atlassian.com/software/jira/downloads/',

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -7,6 +7,10 @@ JIRA_HOME="<%= scope.lookupvar('jira::homedir') %>"
 # Additional JAVA_OPTS
 #
 JAVA_OPTS="<%= scope.lookupvar('jira::java_opts') %> $JAVA_OPTS"
+#
+# Additional CATALINA_OPTS
+#
+CATALINA_OPTS="<%= scope.lookupvar('jira::catalina_opts') %> $CATALINA_OPTS"
 
 #
 #  Occasionally Atlassian Support may recommend that you set some specific JVM arguments.  You can use this variable below to do that.
@@ -76,7 +80,7 @@ if [ -f "${PRGDIR}/permgen.sh" ]; then
     fi
 fi
 
-export JAVA_OPTS
+export JAVA_OPTS CATALINA_OPTS
 
 echo ""
 echo "If you encounter issues starting or stopping JIRA, please see the Troubleshooting guide at http://confluence.atlassian.com/display/JIRA/Installation+Troubleshooting+Guide"


### PR DESCRIPTION
… java_ops is reused for shutdown and therefore fails due to the port being inuse