### PR TITLE
Fix for jira::facts not working with All-in-One Puppet 4.x agent

### DIFF
--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -30,6 +30,9 @@ class jira::facts(
   if $::puppetversion =~ /Puppet Enterprise/ {
     $ruby_bin = '/opt/puppet/bin/ruby'
     $dir      = 'puppetlabs/'
+  } elsif $::aio_agent_version {
+    $ruby_bin = '/opt/puppetlabs/puppet/bin/ruby'
+    $dir      = ''
   } else {
     $ruby_bin = '/usr/bin/env ruby'
     $dir      = ''


### PR DESCRIPTION
This is a propose fix for issue #151. I have not been able to do any testing with other version of puppet, so I don't know if it would break anything with puppet 3.x.
