### PR TITLE
Enhanced support for new products (JIRA Sofware, Core & Servicedesk).

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,45 @@ Some more crowd.properties for SSO, see atlassian documentation for details
 
 ### Hiera examples
 
+#### JIRA 7 examples
+This example is relevant for jira software or core from version 7
+
+```yaml
+jira::version:       '7.1.8'
+jira::product_type:  'software'
+jira::installdir:    '/opt/atlassian/atlassian-jira'
+jira::homedir:       '/opt/atlassian/application-data/jira-home'
+jira::user:          'jira'
+jira::group:         'jira'
+jira::shell:         '/bin/bash'
+jira::dbserver:      'dbvip.example.co.za'
+jira::javahome:      '/opt/java'
+jira::java_opts: >
+  -Dhttp.proxyHost=proxy.example.co.za
+  -Dhttp.proxyPort=8080
+  -Dhttps.proxyHost=proxy.example.co.za
+  -Dhttps.proxyPort=8080
+  -Dhttp.nonProxyHosts=localhost\|127.0.0.1\|172.*.*.*\|10.*.*.*
+  -XX:+UseLargePages'
+jira::dbport:        '5439'
+jira::dbuser:        'jira'
+jira::jvm_xms:       '1G'
+jira::jvm_xmx:       '3G'
+jira::jvm_permgen:   '384m'
+jira::service_manage: false
+jira::enable_connection_pooling: 'true'
+jira::env:
+  - 'http_proxy=proxy.example.co.za:8080'
+  - 'https_proxy=proxy.example.co.za:8080'
+jira::proxy:
+  scheme:    'https'
+  proxyName: 'jira.example.co.za'
+  proxyPort: '443'
+jira::contextpath: '/jira'
+```
+If you are installing the latest jira version for example 7.1.9 @ 12.07.2016 set als the parameter jira::latest_version: true.
+Atlassian offers the latest version under an different path the older versions.
+
 This example is used in production for 2000 users in an traditional enterprise environment. Your mileage may vary. The dbpassword can be stored using eyaml hiera extension.
 
 ```yaml

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,8 +33,10 @@
 class jira (
 
   # Jira Settings
-  $version      = '6.4.1',
+  $version      = '7.1.8',
+  $latest_version = undef,
   $product      = 'jira',
+  $product_type = 'software',
   $format       = 'tar.gz',
   $installdir   = '/opt/jira',
   $homedir      = '/home/jira',
@@ -96,12 +98,12 @@ class jira (
   $catalina_opts    = '',
 
   # Misc Settings
-  $download_url          = 'https://downloads.atlassian.com/software/jira/downloads/',
+  $download_url          = 'https://downloads.atlassian.com/software/jira/downloads',
   $checksum              = undef,
   $disable_notifications = false,
 
   # Choose whether to use puppet-staging, or puppet-archive
-  $deploy_module = 'archive',
+  $deploy_module = 'staging',
 
   # Manage service
   $service_manage = true,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -44,13 +44,34 @@ class jira::install {
 
   # Examples of product tarballs from Atlassian
   # Core                - atlassian-jira-core-7.0.3.tar.gz
+  # Service Desk        - atlassian-servicedesk-3.1.9.tar.gz
   # Software (pre-7)    - atlassian-jira-6.4.12.tar.gz
-  # Software (7 and up) - atlassian-jira-software-7.0.4-jira-7.0.4.tar.gz
+  # Software latest     - atlassian-jira-software-7.1.9.tar.gz
+  # Software (7 and up) - atlassian-jira-software-7.1.8-jira-7.1.8.tar.gz
 
-  if ((versioncmp($jira::version, '7.0.0') < 0) or ($jira::product_name == 'jira-core')) {
-    $file = "atlassian-${jira::product_name}-${jira::version}.${jira::format}"
-  } else {
-    $file = "atlassian-${jira::product_name}-${jira::version}-jira-${jira::version}.${jira::format}"
+  # https://downloads.atlassian.com/software/jira/downloads/atlassian-jira-7.1.9.tar.gz
+  # https://downloads.atlassian.com/software/jira/downloads/atlassian-jira-software-7.1.9.tar.gz
+
+  if $jira::product_type {
+
+    case $jira::product_type {
+
+      'servicedesk':{
+          $file = "atlassian-${jira::product_type}-${jira::version}.${jira::format}"
+      }
+      'core','software':{
+        if ! $jira::latest_version{
+          $file = "atlassian-${jira::product}-${jira::product_type}-${jira::version}-${jira::product}-${jira::version}.${jira::format}"
+        }
+        else {
+          $file = "atlassian-${jira::product}-${jira::product_type}-${jira::version}.${jira::format}"
+        }
+      }
+    }
+  }
+
+  else {
+    $file = "atlassian-${jira::product}-${jira::version}.${jira::format}"
   }
 
   if ! defined(File[$jira::extractdir]) {


### PR DESCRIPTION
Atlassian publish their artifacts in multiple variants depending on software type and version (Core, Software, Servicedesk etc.). I added some small improvements to build the correct download path in dependency of the given JIRA Version and JIRA Product type. 
Please merge it after you verified it. The current version of your module isn't applicable for the latest JIRA Version.

Best regards
Taulant