### PR TITLE
Fixed JIRA 7.1.x download URL.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -46,8 +46,9 @@ class jira::install {
   # Core                - atlassian-jira-core-7.0.3.tar.gz
   # Software (pre-7)    - atlassian-jira-6.4.12.tar.gz
   # Software (7 and up) - atlassian-jira-software-7.0.4-jira-7.0.4.tar.gz
+  # Software (7.2+)     - atlassian-jira-software-7.2.1.tar.gz
 
-  if ((versioncmp($jira::version, '7.0.0') < 0) or ($jira::product_name == 'jira-core')) {
+  if ((versioncmp($jira::version, '7.0.0') < 0) or ($jira::product_name == 'jira-core') or (versioncmp($jira::version, '7.2.0') >= 0)) {
     $file = "atlassian-${jira::product_name}-${jira::version}.${jira::format}"
   } else {
     $file = "atlassian-${jira::product_name}-${jira::version}-jira-${jira::version}.${jira::format}"


### PR DESCRIPTION
Atlassian has changed name convention for JIRA Software 7.2+. This commit fixes it. 

