### PR TITLE
Added parameter for alternative data_dir

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,6 +15,13 @@
 # -----------------------------------------------------------------------------
 class jira::config inherits jira {
 
+  if defined(File[$jira::data_dir]) {
+    $data_dir = $jira::data_dir
+  }
+  else {
+    $data_dir = $jira::home
+  }
+
   File {
     owner => $jira::user,
     group => $jira::group,
@@ -54,7 +61,7 @@ class jira::config inherits jira {
     notify  => Class['jira::service'],
   } ->
 
-  file { "${jira::homedir}/dbconfig.xml":
+  file { "${data_dir}/dbconfig.xml":
     content => template("jira/dbconfig.${jira::db}.xml.erb"),
     mode    => '0600',
     require => [ Class['jira::install'],File[$jira::homedir] ],
@@ -74,7 +81,7 @@ class jira::config inherits jira {
     notify  => Class['jira::service'],
   }
 
-  file { "${jira::homedir}/jira-config.properties":
+  file { "${data_dir}/jira-config.properties":
     content => template('jira/jira-config.properties.erb'),
     mode    => '0600',
     require => [ Class['jira::install'],File[$jira::homedir] ],
@@ -82,7 +89,7 @@ class jira::config inherits jira {
   }
 
   if $jira::datacenter {
-    file { "${jira::homedir}/cluster.properties":
+    file { "${data_dir}/cluster.properties":
       content => template('jira/cluster.properties.erb'),
       mode    => '0600',
       require => [ Class['jira::install'],File[$jira::homedir] ],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,12 +15,7 @@
 # -----------------------------------------------------------------------------
 class jira::config inherits jira {
 
-  if $jira::data_dir {
-    $data_dir = $jira::data_dir
-  }
-  else {
-    $data_dir = $jira::home
-  }
+  $_data_dir = pick($jira::data_dir, $jira::home)
 
   File {
     owner => $jira::user,
@@ -61,7 +56,7 @@ class jira::config inherits jira {
     notify  => Class['jira::service'],
   } ->
 
-  file { "${data_dir}/dbconfig.xml":
+  file { "${_data_dir}/dbconfig.xml":
     content => template("jira/dbconfig.${jira::db}.xml.erb"),
     mode    => '0600',
     require => [ Class['jira::install'],File[$jira::homedir] ],
@@ -81,7 +76,7 @@ class jira::config inherits jira {
     notify  => Class['jira::service'],
   }
 
-  file { "${data_dir}/jira-config.properties":
+  file { "${_data_dir}/jira-config.properties":
     content => template('jira/jira-config.properties.erb'),
     mode    => '0600',
     require => [ Class['jira::install'],File[$jira::homedir] ],
@@ -89,7 +84,7 @@ class jira::config inherits jira {
   }
 
   if $jira::datacenter {
-    file { "${data_dir}/cluster.properties":
+    file { "${_data_dir}/cluster.properties":
       content => template('jira/cluster.properties.erb'),
       mode    => '0600',
       require => [ Class['jira::install'],File[$jira::homedir] ],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,7 +19,7 @@ class jira::config inherits jira {
     $data_dir = $jira::data_dir
   }
   else {
-    $data_dir = $jira::home
+    $data_dir = ${jira::home}
   }
 
   File {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,7 +15,7 @@
 # -----------------------------------------------------------------------------
 class jira::config inherits jira {
 
-  if defined(File[$jira::data_dir]) {
+  if $jira::data_dir {
     $data_dir = $jira::data_dir
   }
   else {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,7 +19,7 @@ class jira::config inherits jira {
     $data_dir = $jira::data_dir
   }
   else {
-    $data_dir = ${jira::home}
+    $data_dir = $jira::home
   }
 
   File {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,7 +15,7 @@
 # -----------------------------------------------------------------------------
 class jira::config inherits jira {
 
-  $_data_dir = pick($jira::data_dir, $jira::home)
+  $_data_dir = pick($jira::data_dir, $jira::homedir)
 
   File {
     owner => $jira::user,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,7 @@ class jira (
   $format       = 'tar.gz',
   $installdir   = '/opt/jira',
   $homedir      = '/home/jira',
+  $data_dir     = undef,
   $user         = 'jira',
   $group        = 'jira',
   $uid          = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,7 +38,7 @@ class jira (
   $format       = 'tar.gz',
   $installdir   = '/opt/jira',
   $homedir      = '/home/jira',
-  $data_dir     = undef,
+  $data_dir     = '',
   $user         = 'jira',
   $group        = 'jira',
   $uid          = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,7 +38,7 @@ class jira (
   $format       = 'tar.gz',
   $installdir   = '/opt/jira',
   $homedir      = '/home/jira',
-  $data_dir     = '',
+  $data_dir     = undef,
   $user         = 'jira',
   $group        = 'jira',
   $uid          = undef,

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -4,7 +4,7 @@
 <% if scope.lookupvar('jira::data_dir') -%>
   JIRA_HOME="<%= scope.lookupvar('jira::data_dir') %>"
 <% else %>
-  JIRA_HOME="<%= scope.lookupvar('jira::home_dir') %>"
+  JIRA_HOME="<%= scope.lookupvar('jira::homedir') %>"
 <% end -%>
 #
 # Additional JAVA_OPTS

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -1,11 +1,7 @@
 #
 # One way to set the JIRA HOME path is here via this variable.  Simply uncomment it and set a valid path like /jira/home.  You can of course set it outside in the command terminal.  That will also work.
 #
-<% if scope.lookupvar('jira::data_dir') -%>
-  JIRA_HOME="<%= scope.lookupvar('jira::data_dir') %>"
-<% else %>
-  JIRA_HOME="<%= scope.lookupvar('jira::homedir') %>"
-<% end -%>
+JIRA_HOME="<%= @_data_dir %>"
 #
 # Additional JAVA_OPTS
 #

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -1,8 +1,11 @@
 #
 # One way to set the JIRA HOME path is here via this variable.  Simply uncomment it and set a valid path like /jira/home.  You can of course set it outside in the command terminal.  That will also work.
 #
-JIRA_HOME="<%= scope.lookupvar('jira::homedir') %>"
-
+<% if scope.lookupvar('jira::data_dir') -%>
+  JIRA_HOME="<%= scope.lookupvar('jira::data_dir') %>"
+<% else %>
+  JIRA_HOME="<%= scope.lookupvar('jira::home_dir') %>"
+<% end -%>
 #
 # Additional JAVA_OPTS
 #
@@ -120,4 +123,3 @@ cd $PUSHED_DIR
 
 echo ""
 echo "Server startup logs are located in $LOGBASEABS/logs/catalina.out"
-


### PR DESCRIPTION
We install our atlassian instances out of the users home dir. So I modified the code to be able to use /opt/atlassian/jira/data as path for the atlassian data. I added a new parameter called jira::data_dir, which is used in config.pp for creating config files. 

Please merge if its ok. I think its also a benefit for other users.

Best regards
Taulant
