### PR TITLE
init.pp should have 'staging' set as the default as specified

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,7 +101,7 @@ class jira (
   $disable_notifications = false,
 
   # Choose whether to use puppet-staging, or puppet-archive
-  $deploy_module = 'archive',
+  $deploy_module = 'staging',
 
   # Manage service
   $service_manage = true,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,6 +16,7 @@
 class jira::install {
 
   include '::archive'
+  include '::staging'
 
   group { $jira::group:
     ensure => present,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

The [README](https://github.com/voxpupuli/puppet-jira#upgrades-to-the-jira-puppet-module) specifies that staging is the default deploy module but archive is still specified within init.pp as default.

This PR corrects that.