### PR TITLE
Atlassian doesn't provide checksums, add checksum_verify false.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,8 @@ The jira::facts class is required for upgrades.
 
 ##### Upgrades to the JIRA puppet Module
 
-mkrakowitzer-deploy has been replaced with nanliu-staging as the default module for
-deploying the JIRA binaries. You can still use mkrakowitzer-deploy with the
-*deploy_module => 'archive'*
+puppet-archive is the default module for
+deploying the JIRA binaries.
 
 ```puppet
   class { 'jira':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -104,6 +104,7 @@ class jira::install {
         source          => "${jira::download_url}/${file}",
         creates         => "${jira::webappdir}/conf",
         cleanup         => true,
+        checksum_verify => false,
         checksum_type   => 'md5',
         checksum        => $jira::checksum,
         user            => $jira::user,

--- a/spec/classes/jira_install_spec.rb
+++ b/spec/classes/jira_install_spec.rb
@@ -89,7 +89,7 @@ describe 'jira' do
             let(:params) do
               {
                 javahome: '/opt/java',
-                version: '6.0.0',
+                version: '6.1',
                 format: 'tar.gz',
                 installdir: '/opt/jira',
                 homedir: '/random/homedir',
@@ -98,7 +98,7 @@ describe 'jira' do
                 uid: 333,
                 gid: 444,
                 shell: '/bin/bash',
-                download_url: 'http://downloads.atlassian.com'
+                download_url: 'https://www.atlassian.com/software/jira/downloads/binary'
               }
             end
 
@@ -110,11 +110,11 @@ describe 'jira' do
             end
             it { is_expected.to contain_group('bar') }
 
-            it 'deploys jira 6.0.0 from tar.gz' do
-              is_expected.to contain_archive('/tmp/atlassian-jira-6.0.0.tar.gz').
-                with('extract_path' => '/opt/jira/atlassian-jira-6.0.0-standalone',
-                     'source'        => 'http://downloads.atlassian.com/atlassian-jira-6.0.0.tar.gz',
-                     'creates'       => '/opt/jira/atlassian-jira-6.0.0-standalone/conf',
+            it 'deploys jira 6.1 from tar.gz' do
+              is_expected.to contain_archive('/tmp/atlassian-jira-6.1.tar.gz').
+                with('extract_path' => '/opt/jira/atlassian-jira-6.1-standalone',
+                     'source'        => 'https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-6.1.tar.gz',
+                     'creates'       => '/opt/jira/atlassian-jira-6.1-standalone/conf',
                      'user'          => 'foo',
                      'group'         => 'bar',
                      'checksum_type' => 'md5')


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

As well, tests specify jira 6.0.0, it's 6.0

Fix jira 6.0 source/download urls

fix jira 6 version as well...

Changing 6.0 to 6.1 as less then 6.1 is EOL

match jira 6.1 source and download urls

While fixing tests for Jira 6.0, I noticed that versions < 6.1 are end of support by Atlassian:
[End Of Support](https://confluence.atlassian.com/jira064/supported-platforms-720411857.html)
I changed the test to use 6.1 instead.