### PR TITLE
Add checksum for modules default version

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Defaults to `https://downloads.atlassian.com/software/jira/downloads/`
 ##### `checksum`
 
 The md5 checksum of the archive file. Only supported with
-`deploy_module => archive`. Defaults to 'undef'
+`deploy_module => archive`. Defaults to '0e4eef936f1956cd2e12407cf0d8f577'
 
 ##### `$deploy_module`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,7 +97,7 @@ class jira (
 
   # Misc Settings
   $download_url          = 'https://downloads.atlassian.com/software/jira/downloads/',
-  $checksum              = undef,
+  $checksum              = '0e4eef936f1956cd2e12407cf0d8f577',
   $disable_notifications = false,
 
   # Choose whether to use puppet-staging, or puppet-archive

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -104,7 +104,6 @@ class jira::install {
         source          => "${jira::download_url}/${file}",
         creates         => "${jira::webappdir}/conf",
         cleanup         => true,
-        checksum_verify => false,
         checksum_type   => 'md5',
         checksum        => $jira::checksum,
         user            => $jira::user,


### PR DESCRIPTION
As long as Atlassian does not provide checksums, we should at least supply one for the default version so that the installation is as straightforward as possible.