### PR TITLE
Use https instead of http

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ defaults to ''
 ##### `$download_url`
 
 The URL used to download the JIRA installation file.
-Defaults to `https://downloads.atlassian.com/software/jira/downloads/`
+Defaults to '<https://www.atlassian.com/software/jira/downloads/binary>'
 
 ##### `checksum`
 

--- a/jira.yaml
+++ b/jira.yaml
@@ -93,7 +93,7 @@ jira::jvm_optional: -XX:-HeapDumpOnOutOfMemoryError
 # the New and SR figures are purely optional
 # for heap dumps add -XX:-HeapDumpOnOutOfMemoryError
 # by default jira has 256m permgen which is a good setting to go with
-jira::download_url: 'https://downloads.atlassian.com/software/jira/downloads/'
+jira::download_url: 'https://www.atlassian.com/software/jira/downloads/binary'
 
 # Should puppet manage this service
 #  Boolean dictating if puppet should manage the service

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,7 +96,7 @@ class jira (
   $catalina_opts    = '',
 
   # Misc Settings
-  $download_url          = 'https://downloads.atlassian.com/software/jira/downloads/',
+  $download_url          = 'https://www.atlassian.com/software/jira/downloads/binary',
   $checksum              = undef,
   $disable_notifications = false,
 

--- a/spec/classes/jira_install_spec.rb
+++ b/spec/classes/jira_install_spec.rb
@@ -20,15 +20,15 @@ describe 'jira' do
                 format: 'tar.gz',
                 product: 'jira',
                 version: '6.3.4a',
-                download_url: 'https://downloads.atlassian.com/software/jira/downloads'
+                download_url: 'https://www.atlassian.com/software/jira/downloads/binary'
               }
             end
             it { is_expected.to contain_group('jira') }
             it { is_expected.to contain_user('jira').with_shell('/bin/true') }
             it 'deploys jira 6.3.4a from tar.gz' do
               is_expected.to contain_archive('/tmp/atlassian-jira-6.3.4a.tar.gz').
-                with('extract_path' => '/opt/jira/atlassian-jira-6.3.4a-standalone',
-                     'source'        => 'https://downloads.atlassian.com/software/jira/downloads/atlassian-jira-6.3.4a.tar.gz',
+                with('extract_path'  => '/opt/jira/atlassian-jira-6.3.4a-standalone',
+                     'source'        => 'https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-6.3.4a.tar.gz',
                      'creates'       => '/opt/jira/atlassian-jira-6.3.4a-standalone/conf',
                      'user'          => 'jira',
                      'group'         => 'jira',
@@ -50,13 +50,13 @@ describe 'jira' do
                   installdir: '/opt/jira',
                   product: 'jira',
                   version: '7.0.4',
-                  download_url: 'http://www.atlassian.com/software/jira/downloads/binary'
+                  download_url: 'https://www.atlassian.com/software/jira/downloads/binary'
                 }
               end
               it 'deploys jira 7.0.4 from tar.gz' do
                 is_expected.to contain_archive('/tmp/atlassian-jira-software-7.0.4-jira-7.0.4.tar.gz').
-                  with('extract_path' => '/opt/jira/atlassian-jira-software-7.0.4-standalone',
-                       'source'        => 'http://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-7.0.4-jira-7.0.4.tar.gz',
+                  with('extract_path'  => '/opt/jira/atlassian-jira-software-7.0.4-standalone',
+                       'source'        => 'https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-7.0.4-jira-7.0.4.tar.gz',
                        'creates'       => '/opt/jira/atlassian-jira-software-7.0.4-standalone/conf',
                        'user'          => 'jira',
                        'group'         => 'jira',
@@ -70,13 +70,13 @@ describe 'jira' do
                   installdir: '/opt/jira',
                   product: 'jira-core',
                   version: '7.0.4',
-                  download_url: 'http://www.atlassian.com/software/jira/downloads/binary'
+                  download_url: 'https://www.atlassian.com/software/jira/downloads/binary'
                 }
               end
               it 'deploys jira 7.0.4 from tar.gz' do
                 is_expected.to contain_archive('/tmp/atlassian-jira-core-7.0.4.tar.gz').
-                  with('extract_path' => '/opt/jira/atlassian-jira-core-7.0.4-standalone',
-                       'source'        => 'http://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-core-7.0.4.tar.gz',
+                  with('extract_path'  => '/opt/jira/atlassian-jira-core-7.0.4-standalone',
+                       'source'        => 'https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-core-7.0.4.tar.gz',
                        'creates'       => '/opt/jira/atlassian-jira-core-7.0.4-standalone/conf',
                        'user'          => 'jira',
                        'group'         => 'jira',
@@ -112,7 +112,7 @@ describe 'jira' do
 
             it 'deploys jira 6.1 from tar.gz' do
               is_expected.to contain_archive('/tmp/atlassian-jira-6.1.tar.gz').
-                with('extract_path' => '/opt/jira/atlassian-jira-6.1-standalone',
+                with('extract_path'  => '/opt/jira/atlassian-jira-6.1-standalone',
                      'source'        => 'https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-6.1.tar.gz',
                      'creates'       => '/opt/jira/atlassian-jira-6.1-standalone/conf',
                      'user'          => 'foo',


### PR DESCRIPTION
We should use https instead of http, even if Atlassian redirects the traffic automatically.