### PR TITLE
Allow management of vendor check-java.sh file

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,10 +418,8 @@ Defaults to an empty string (""). Will add a path to the Tomcat Server Context.
 
 ##### `$script_check_java_manage`
 
-Manages a modified version of the 'check-java.sh' script provided by
-JIRA in order to use OpenJDK.
-
-Note: JIRA does not officially support OpenJDK.
+Manages a the 'check-java.sh' script provided by
+JIRA.
 
 Defaults to 'false'.
 

--- a/README.md
+++ b/README.md
@@ -416,6 +416,22 @@ Defaults to {}, See examples on how to use.
 
 Defaults to an empty string (""). Will add a path to the Tomcat Server Context.
 
+##### `$script_check_java_manage`
+
+Manages a modified version of the 'check-java.sh' script provided by
+JIRA in order to use OpenJDK. (Requires JIRA > 7.0.0)
+
+Note: JIRA does not officially support OpenJDK.
+
+Defaults to 'false'.
+
+##### `$script_check_java_template`
+
+Alternate location to find the 'check-java.sh' script. Requires
+`$manage_script_check_java = true`.
+
+Defaults to undef.
+
 #### Tomcat parameters
 
 ##### `$tomcat_address`

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ Defaults to an empty string (""). Will add a path to the Tomcat Server Context.
 ##### `$script_check_java_manage`
 
 Manages a modified version of the 'check-java.sh' script provided by
-JIRA in order to use OpenJDK. (Requires JIRA > 7.0.0)
+JIRA in order to use OpenJDK.
 
 Note: JIRA does not officially support OpenJDK.
 
@@ -428,9 +428,9 @@ Defaults to 'false'.
 ##### `$script_check_java_template`
 
 Alternate location to find the 'check-java.sh' script. Requires
-`$manage_script_check_java = true`.
+`$script_check_java_manage = true`.
 
-Defaults to undef.
+Defaults to 'jira/check-java.sh.erb'.
 
 #### Tomcat parameters
 

--- a/files/check-java.sh
+++ b/files/check-java.sh
@@ -1,0 +1,23 @@
+
+#!/bin/sh
+
+_EXPECTED_JAVA_VERSION="8"
+
+#
+# check for correct java version by parsing out put of java -version
+# we expect first line to be in format 'version "1.8.0_40"' and assert that minor version number will be 8 or higher
+#
+
+"$_RUNJAVA" -version 2>&1 | grep "version" | (
+        IFS=. read ignore1 version ignore2
+        if [ ! ${version:-0} -ge "$_EXPECTED_JAVA_VERSION" ]
+        then
+           echo "*************************************************************************************************************************************"
+           echo "**********     Wrong JVM version! You are running with "$ignore1"."$version"."$ignore2" but JIRA requires at least 1.8 to run.      **********"
+           echo "*************************************************************************************************************************************"
+           exit 1
+        fi
+    )
+if [ $? -ne 0 ] ; then
+   exit 1
+fi

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -54,15 +54,22 @@ class jira::config inherits jira {
     notify  => Class['jira::service'],
   }
 
-  if (versioncmp($jira::version, '7.0.0') >= 0) {
-    file { "${jira::webappdir}/bin/check-java.sh":
-      source  => "puppet:///modules/${module_name}/check-java.sh",
-      mode    => '0755',
-      require => [
-        Class['jira::install'],
-        File["${jira::webappdir}/bin/setenv.sh"],
-      ],
-      notify  => Class['jira::service'],
+  if $jira::script_check_java_manage {
+    if $jira::script_check_java_template == undef {
+      $script_check_java_location = "puppet:///modules/${module_name}/check-java.sh"
+    } else {
+      $script_check_java_location = $jira::script_check_java_template
+    }
+    if (versioncmp($jira::version, '7.0.0') >= 0) {
+      file { "${jira::webappdir}/bin/check-java.sh":
+        source  => $script_check_java_location,
+        mode    => '0755',
+        require => [
+          Class['jira::install'],
+          File["${jira::webappdir}/bin/setenv.sh"],
+        ],
+        notify  => Class['jira::service'],
+      }
     }
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -52,36 +52,25 @@ class jira::config inherits jira {
     mode    => '0755',
     require => Class['jira::install'],
     notify  => Class['jira::service'],
-  }
-
-  if $jira::script_check_java_manage {
-    if $jira::script_check_java_template == undef {
-      $script_check_java_location = "puppet:///modules/${module_name}/check-java.sh"
-    } else {
-      $script_check_java_location = $jira::script_check_java_template
-    }
-    if (versioncmp($jira::version, '7.0.0') >= 0) {
-      file { "${jira::webappdir}/bin/check-java.sh":
-        source  => $script_check_java_location,
-        mode    => '0755',
-        require => [
-          Class['jira::install'],
-          File["${jira::webappdir}/bin/setenv.sh"],
-        ],
-        notify  => Class['jira::service'],
-      }
-    }
-  }
+  } ->
 
   file { "${jira::homedir}/dbconfig.xml":
     content => template("jira/dbconfig.${jira::db}.xml.erb"),
     mode    => '0600',
-    require => [
-      Class['jira::install'],
-      File["${jira::webappdir}/bin/setenv.sh"],
-      File[$jira::homedir],
-    ],
+    require => [ Class['jira::install'],File[$jira::homedir], ],
     notify  => Class['jira::service'],
+  }
+
+  if $jira::script_check_java_manage {
+    file { "${jira::webappdir}/bin/check-java.sh":
+      content => template($jira::script_check_java_template),
+      mode    => '0755',
+      require => [
+        Class['jira::install'],
+        File["${jira::webappdir}/bin/setenv.sh"],
+      ],
+      notify  => Class['jira::service'],
+    }
   }
 
   file { "${jira::webappdir}/conf/server.xml":

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -57,7 +57,7 @@ class jira::config inherits jira {
   file { "${jira::homedir}/dbconfig.xml":
     content => template("jira/dbconfig.${jira::db}.xml.erb"),
     mode    => '0600',
-    require => [ Class['jira::install'],File[$jira::homedir], ],
+    require => [ Class['jira::install'],File[$jira::homedir] ],
     notify  => Class['jira::service'],
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -52,12 +52,28 @@ class jira::config inherits jira {
     mode    => '0755',
     require => Class['jira::install'],
     notify  => Class['jira::service'],
-  } ->
+  }
+
+  if (versioncmp($jira::version, '7.0.0') >= 0) {
+    file { "${jira::webappdir}/bin/check-java.sh":
+      source  => "puppet:///modules/${module_name}/check-java.sh",
+      mode    => '0755',
+      require => [
+        Class['jira::install'],
+        File["${jira::webappdir}/bin/setenv.sh"],
+      ],
+      notify  => Class['jira::service'],
+    }
+  }
 
   file { "${jira::homedir}/dbconfig.xml":
     content => template("jira/dbconfig.${jira::db}.xml.erb"),
     mode    => '0600',
-    require => [ Class['jira::install'],File[$jira::homedir] ],
+    require => [
+      Class['jira::install'],
+      File["${jira::webappdir}/bin/setenv.sh"],
+      File[$jira::homedir],
+    ],
     notify  => Class['jira::service'],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,6 +113,10 @@ class jira (
   # incase the jira service is managed outside of puppet. eg: using the
   # puppetlabs-corosync module: 'crm resource stop jira && sleep 15'
   $stop_jira = 'service jira stop && sleep 15',
+  # Whether to manage the 'check-java.sh' script, and where to retrieve
+  # the script from.
+  $script_check_java_manage = false,
+  $script_check_java_template = undef,
 
   # Tomcat
   $tomcat_address                   = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -116,7 +116,7 @@ class jira (
   # Whether to manage the 'check-java.sh' script, and where to retrieve
   # the script from.
   $script_check_java_manage = false,
-  $script_check_java_template = undef,
+  $script_check_java_template = 'jira/check-java.sh.erb',
 
   # Tomcat
   $tomcat_address                   = undef,

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -27,6 +27,7 @@ describe 'jira' do
                 with_content(%r{<schema-name>public</schema-name>})
             end
             it { is_expected.not_to contain_file('/home/jira/cluster.properties') }
+            it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/bin/check-java.sh') }
           end
 
           context 'mysql params' do
@@ -388,41 +389,17 @@ describe 'jira' do
             end
           end
 
-          context 'check-java override' do
-            context 'on pre 7 jira' do
-              let(:params) do
-                {
-                  version: '6.3.4a',
-                  javahome: '/opt/java'
-                }
-              end
-              it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-7.0.4-standalone/bin/check-java.sh') }
+          context 'with script_check_java_managed enabled' do
+            let(:params) do
+              {
+                script_check_java_manage: true,
+                version: '7.0.4',
+                javahome: '/opt/java'
+              }
             end
-            context 'on jira 7 and later' do
-              context 'with script_check_java_managed enabled' do
-                let(:params) do
-                  {
-                    script_check_java_manage: true,
-                    version: '7.0.4',
-                    javahome: '/opt/java'
-                  }
-                end
-                it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-7.0.4-standalone/bin/check-java.sh') }
-              end
-              context 'with script_check_java_template set' do
-                let(:params) do
-                  {
-                    script_check_java_manage: true,
-                    script_check_java_template: 'puppet::///modules/private/my-check-java.sh',
-                    version: '7.0.4',
-                    javahome: '/opt/java'
-                  }
-                end
-                it do
-                  is_expected.to contain_file('/opt/jira/atlassian-jira-software-7.0.4-standalone/bin/check-java.sh').
-                    with('source' => 'puppet::///modules/private/my-check-java.sh')
-                end
-              end
+            it do
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-7.0.4-standalone/bin/check-java.sh')
+                .with_content(%r{Wrong JVM version})
             end
           end
 

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -388,6 +388,27 @@ describe 'jira' do
             end
           end
 
+          context 'check-java override' do
+            context 'on pre 7 jira' do
+              let(:params) do
+                {
+                  version: '6.3.4a',
+                  javahome: '/opt/java'
+                }
+              end
+              it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-7.0.4-standalone/bin/check-java.sh') }
+            end
+            context 'on jira 7 and later' do
+              let(:params) do
+                {
+                  version: '7.0.4',
+                  javahome: '/opt/java'
+                }
+              end
+              it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-7.0.4-standalone/bin/check-java.sh') }
+            end
+          end
+
           context 'context resources' do
             let(:params) do
               {

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -398,8 +398,8 @@ describe 'jira' do
               }
             end
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-software-7.0.4-standalone/bin/check-java.sh')
-                .with_content(%r{Wrong JVM version})
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-7.0.4-standalone/bin/check-java.sh').
+                with_content(%r{Wrong JVM version})
             end
           end
 

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -399,13 +399,30 @@ describe 'jira' do
               it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-7.0.4-standalone/bin/check-java.sh') }
             end
             context 'on jira 7 and later' do
-              let(:params) do
-                {
-                  version: '7.0.4',
-                  javahome: '/opt/java'
-                }
+              context 'with script_check_java_managed enabled' do
+                let(:params) do
+                  {
+                    script_check_java_manage: true,
+                    version: '7.0.4',
+                    javahome: '/opt/java'
+                  }
+                end
+                it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-7.0.4-standalone/bin/check-java.sh') }
               end
-              it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-7.0.4-standalone/bin/check-java.sh') }
+              context 'with script_check_java_template set' do
+                let(:params) do
+                  {
+                    script_check_java_manage: true,
+                    script_check_java_template: 'puppet::///modules/private/my-check-java.sh',
+                    version: '7.0.4',
+                    javahome: '/opt/java'
+                  }
+                end
+                it do
+                  is_expected.to contain_file('/opt/jira/atlassian-jira-software-7.0.4-standalone/bin/check-java.sh').
+                    with('source' => 'puppet::///modules/private/my-check-java.sh')
+                end
+              end
             end
           end
 

--- a/templates/check-java.sh.erb
+++ b/templates/check-java.sh.erb
@@ -1,10 +1,8 @@
 #!/bin/sh
 # This file is managed by Puppet
-#
+
 # This file should be identical to 'check-java.sh' in the Jira 7.0.4 standalone
-# tarball, with 2 exceptions: 'grep "java version"' has been changed
-# to 'grep "version"' in order to allow JIRA to run on OpenJDK, and the
-# 'managed by Puppet' header was added along with this comment.
+# tarball.
 
 _EXPECTED_JAVA_VERSION="8"
 
@@ -13,7 +11,7 @@ _EXPECTED_JAVA_VERSION="8"
 # we expect first line to be in format 'java version "1.8.0_40"' and assert that minor version number will be 8 or higher
 #
 
-"$_RUNJAVA" -version 2>&1 | grep "version" | (
+"$_RUNJAVA" -version 2>&1 | grep "java version" | (
         IFS=. read ignore1 version ignore2
         if [ ! ${version:-0} -ge "$_EXPECTED_JAVA_VERSION" ]
         then

--- a/templates/check-java.sh.erb
+++ b/templates/check-java.sh.erb
@@ -1,11 +1,16 @@
-
 #!/bin/sh
+# This file is managed by Puppet
+#
+# This file should be identical to 'check-java.sh' in the Jira 7.0.4 standalone
+# tarball, with 2 exceptions: 'grep "java version"' has been changed
+# to 'grep "version"' in order to allow JIRA to run on OpenJDK, and the
+# 'managed by Puppet' header was added along with this comment.
 
 _EXPECTED_JAVA_VERSION="8"
 
 #
 # check for correct java version by parsing out put of java -version
-# we expect first line to be in format 'version "1.8.0_40"' and assert that minor version number will be 8 or higher
+# we expect first line to be in format 'java version "1.8.0_40"' and assert that minor version number will be 8 or higher
 #
 
 "$_RUNJAVA" -version 2>&1 | grep "version" | (


### PR DESCRIPTION
The script which checks for Java assumes Oracle Java, and thus wrongly
checks the version string output to be prefixed with 'java' and not
'openjdk'. This change removes the check for JIRA 7 and up.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>