### PR TITLE
Bump puppet minimum version_requirement to 3.8.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ enabled in order to upgrade to new JIRA versions smoothly.
 
 ## Limitations
 
-* Puppet 3.7+
+* Puppet 3.8.7+
 * Puppet Enterprise
 
 The puppetlabs repositories can be found at:

--- a/metadata.json
+++ b/metadata.json
@@ -27,12 +27,8 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">=3.7.0 <4.0.0"
-    },
-    {
       "name": "puppet",
-      "version_requirement": ">=3.7.0 <4.0.0"
+      "version_requirement": ">=3.8.7 <5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet 3 versions