### PR TITLE
FIX version checking regex 

### DIFF
--- a/spec/acceptance/default_parameters_spec.rb
+++ b/spec/acceptance/default_parameters_spec.rb
@@ -90,7 +90,7 @@ describe 'jira postgresql', unless: UNSUPPORTED_PLATFORMS.include?(fact('osfamil
   end
 
   describe command('wget -q --tries=240 --retry-connrefused --read-timeout=10 -O- localhost:8080') do
-    its(:stdout) { is_expected.to match(%r{6\.2\.7}) }
+    its(:stdout) { is_expected.to match(%r{6\.3\.4a}) }
   end
 
   describe 'shutdown' do


### PR DESCRIPTION
Fairly sure I had amended this before but at any rate that didn't make it into the last PR #197. Most likely (PEBCAK) 😈 
This fixes:
- The version check doesn't match version

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
