### PR TITLE
Fix tls connector protocol

### DIFF
--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -73,7 +73,7 @@
 <% if @tomcat_native_ssl -%>
         <Connector
                     port="<%= @tomcat_https_port %>"
-                    protocol="org.apache.coyote.http11.Http11Protocol"
+                    protocol="org.apache.coyote.http11.Http11NioProtocol"
                     <%- if @tomcat_address -%>
                     address="<%= @tomcat_address %>"
                     <%- end -%>


### PR DESCRIPTION
for jira version 7.3, the tls protocol has been changed to : org.apache.coyote.http11.Http11NioProtocol.
This is a quick fix. Do you guys think we should be sending this as a hiera parameter or have an if else statement on the jira version number?