### PR TITLE
Add $tomcat_protocol_ssl paramater for compatibility with Jira >= 7.3.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -120,6 +120,7 @@ class jira (
   $tomcat_https_port                                                = 8443,
   Optional[Integer] $tomcat_redirect_https_port                     = undef,
   $tomcat_protocol                                                  = 'HTTP/1.1',
+  $tomcat_protocol_ssl                                              = 'org.apache.coyote.http11.Http11Protocol',
   $tomcat_use_body_encoding_for_uri                                 = true,
   $tomcat_disable_upload_timeout                                    = true,
   $tomcat_key_alias                                                 = 'jira',

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -73,7 +73,7 @@
 <% if @tomcat_native_ssl -%>
         <Connector
                     port="<%= @tomcat_https_port %>"
-                    protocol="org.apache.coyote.http11.Http11Protocol"
+                    protocol="<%= @tomcat_protocol_ssl %>"
                     <%- if @tomcat_address -%>
                     address="<%= @tomcat_address %>"
                     <%- end -%>


### PR DESCRIPTION
Tomcat connector protocol changed in Jira 7.3:

https://confluence.atlassian.com/jiracore/jira-core-7-3-x-upgrade-notes-861251104.html

This will allow you to set the correct connector value (org.apache.coyote.http11.Http11NioProtocol) when using Jira 7.3 and higher.