### PR TITLE
switch to using ensure_packages to avoid conflicts

### DIFF
--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -49,9 +49,7 @@ class jira::facts (
   }
 
   if $facts['osfamily'] == 'RedHat' and $facts['puppetversion'] !~ /Puppet Enterprise/ {
-    package { $json_packages:
-      ensure => present,
-    }
+    ensure_packages ($json_packages, { ensure => present })
   }
 
   file { "/etc/${dir}facter/facts.d/jira_facts.rb":

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class jira::params {
   case $facts['osfamily'] {
     /RedHat/: {
       if versioncmp($facts['operatingsystemmajrelease'], '7') >= 0 {
-        $json_packages = 'rubygem-json'
+        $json_packages = [ 'rubygem-json' ]
         $service_file_location = '/usr/lib/systemd/system/jira.service'
         $service_file_template = 'jira/jira.service.erb'
         $service_lockfile = '/var/lock/subsys/jira'
@@ -29,7 +29,7 @@ class jira::params {
       case $::operatingsystem {
         'Ubuntu': {
           if versioncmp($facts['operatingsystemmajrelease'], '15.04') >= 0 {
-            $json_packages = 'ruby-json'
+            $json_packages = [ 'ruby-json' ]
             $service_file_location = '/lib/systemd/system/jira.service'
             $service_file_template = 'jira/jira.service.erb'
             $service_lockfile = '/var/lock/subsys/jira'
@@ -44,7 +44,7 @@ class jira::params {
         }
         default: {
           if versioncmp($facts['operatingsystemmajrelease'], '8') >= 0 {
-            $json_packages = 'ruby-json'
+            $json_packages = [ 'ruby-json' ]
             $service_file_location = '/lib/systemd/system/jira.service'
             $service_file_template = 'jira/jira.service.erb'
             $service_lockfile = '/var/lock/subsys/jira'


### PR DESCRIPTION
If sharing the same server for several atlassian products (crowd, jira, confluence, bitbucket) there may be conflicts with packages.  This shows up with the bitbucket and jira modules both expecting one or both of `rubygem-json` and `ruby-json`.  Switching to `ensure_packages` allows both projects to declare the package requirement.

Correspond PR in related project: https://github.com/danofthewired/puppet-bitbucket/pull/60