### PR TITLE
Update server.xml.erb to account for weird Service Desk versioning

### DIFF
--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -32,7 +32,7 @@
     <!--APR library loader. Documentation at /docs/apr.html -->
     <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
     <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener"/>
-<%- if scope.function_versioncmp([@version, '6.4.14']) <= 0 -%>
+<%- if scope.function_versioncmp([@version, '6.4.14']) <= 0 && @product =~ /^jira/ -%>
     <Listener className="org.apache.catalina.core.JasperListener"/>
 <% else -%>
     <Listener className="org.apache.catalina.startup.VersionLoggerListener" />


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
If you set `$product = 'servicedesk'` (which allows you to install the Jira Service Desk application, a superset of Jira Server), its versioning is currently in the 3.x range, which hits this line in `server.xml.erb` and causes the older JasperListener to be called at startup and it will fail.  This has been tested with `$product = 'servicedesk'` and `$version = '3.12.2'`.