### PR TITLE
Allow homedir to be managed from outside of module

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -126,7 +126,7 @@ class jira::install {
     }
   }
 
-  file { $jira::homedir:
+  if ! defined(File[$jira::homedir]) {
     ensure => 'directory',
     owner  => $jira::user,
     group  => $jira::group,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -127,9 +127,11 @@ class jira::install {
   }
 
   if ! defined(File[$jira::homedir]) {
-    ensure => 'directory',
-    owner  => $jira::user,
-    group  => $jira::group,
+    file { $jira::homedir:
+      ensure => 'directory',
+      owner  => $jira::user,
+      group  => $jira::group,
+    }
   }
 
   -> exec { "chown_${jira::extractdir}":

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,7 +29,7 @@ class jira::install {
       password         => '*',
       password_min_age => '0',
       password_max_age => '99999',
-      managehome       => true,
+      managehome       => false,
       uid              => $jira::uid,
       gid              => $jira::gid,
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -134,10 +134,11 @@ class jira::install {
     }
   }
 
-  -> exec { "chown_${jira::extractdir}":
+  exec { "chown_${jira::extractdir}":
     command     => "/bin/chown -R ${jira::user}:${jira::group} ${jira::extractdir}",
     refreshonly => true,
     subscribe   => User[$jira::user],
+    require     => File[$jira::homedir],
   }
 
   if $jira::db == 'mysql' and $jira::mysql_connector_manage {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,7 +29,10 @@ class jira::install {
       password         => '*',
       password_min_age => '0',
       password_max_age => '99999',
-      managehome       => false,
+      managehome       => defined(File[$jira::homedir]) ? {
+        true    => false,
+        default => true,
+      },
       uid              => $jira::uid,
       gid              => $jira::gid,
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -29,7 +29,7 @@ class jira::service(
 
   file { $service_file_location:
     content => template($service_file_template),
-    mode    => '0755',
+    mode    => '0644',
   }
 
   if $service_manage {


### PR DESCRIPTION
#### Pull Request (PR) description
We run Jira in a cluster setup (pacemaker). For that we need to have the homedir of Jira (which is also the "data" directory) on a NFS share. The NFS mount is done to another directory and the data dir is a symlink, which is managed outside of this jira module. To be able to do that, i needed to fix the jira module to not handle the homedir, if done from outside. I think it will be useful for others, who are building similar setups, hence this pull request.

#### This Pull Request (PR) fixes the following issues
n/a