### PR TITLE
Change download_url default value

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,7 +90,7 @@ class jira (
   $java_opts                                                        = '',
   $catalina_opts                                                    = '',
   # Misc Settings
-  Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl] $download_url          = 'https://downloads.atlassian.com/software/jira/downloads/',
+  Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl] $download_url          = 'https://product-downloads.atlassian.com/software/jira/downloads/',
   $checksum                                                         = undef,
   $disable_notifications                                            = false,
   # Choose whether to use puppet-staging, or puppet-archive


### PR DESCRIPTION
The latest version (7.13.1 for today) isn't available in the location currently
used in module. Use new location as per [1]

[1]: https://www.atlassian.com/software/jira/download

Signed-off-by: Anton Baranov <abaranov@linuxfoundation.org>

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
