### PR TITLE
Update default `download_url`

### DIFF
--- a/jira.yaml
+++ b/jira.yaml
@@ -93,7 +93,7 @@ jira::jvm_optional: -XX:-HeapDumpOnOutOfMemoryError
 # the New and SR figures are purely optional
 # for heap dumps add -XX:-HeapDumpOnOutOfMemoryError
 # by default jira has 256m permgen which is a good setting to go with
-jira::download_url: 'https://downloads.atlassian.com/software/jira/downloads/'
+jira::download_url: 'https://product-downloads.atlassian.com/software/jira/downloads'
 
 # Should puppet manage this service
 #  Boolean dictating if puppet should manage the service

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,7 +70,7 @@ class jira (
   $mysql_connector_product                                          = 'mysql-connector-java',
   $mysql_connector_format                                           = 'tar.gz',
   Stdlib::Absolutepath $mysql_connector_install                     = '/opt/MySQL-connector',
-  Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl] $mysql_connector_url   = 'https://dev.mysql.com/get/Downloads/Connector-J',
+  Stdlib::HTTPUrl $mysql_connector_url                              = 'https://dev.mysql.com/get/Downloads/Connector-J',
   # Configure database settings if you are pooling connections
   $enable_connection_pooling                                        = false,
   $pool_min_size                                                    = 20,
@@ -93,7 +93,7 @@ class jira (
   $java_opts                                                        = '',
   $catalina_opts                                                    = '',
   # Misc Settings
-  Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl] $download_url          = 'https://downloads.atlassian.com/software/jira/downloads/',
+  Stdlib::HTTPUrl $download_url                                     = 'https://product-downloads.atlassian.com/software/jira/downloads',
   $checksum                                                         = undef,
   $disable_notifications                                            = false,
   # Choose whether to use puppet-staging, or puppet-archive

--- a/spec/classes/jira_install_spec.rb
+++ b/spec/classes/jira_install_spec.rb
@@ -20,7 +20,7 @@ describe 'jira' do
                 format:       'tar.gz',
                 product:      'jira',
                 version:      '6.3.4a',
-                download_url: 'https://downloads.atlassian.com/software/jira/downloads'
+                download_url: 'https://product-downloads.atlassian.com/software/jira/downloads'
               }
             end
 
@@ -30,7 +30,7 @@ describe 'jira' do
             it 'deploys jira 6.3.4a from tar.gz' do
               is_expected.to contain_archive('/tmp/atlassian-jira-6.3.4a.tar.gz').
                 with('extract_path'  => '/opt/jira/atlassian-jira-6.3.4a-standalone',
-                     'source'        => 'https://downloads.atlassian.com/software/jira/downloads/atlassian-jira-6.3.4a.tar.gz',
+                     'source'        => 'https://product-downloads.atlassian.com/software/jira/downloads/atlassian-jira-6.3.4a.tar.gz',
                      'creates'       => '/opt/jira/atlassian-jira-6.3.4a-standalone/conf',
                      'user'          => 'jira',
                      'group'         => 'jira',


### PR DESCRIPTION
Fixes #285

Also replace `Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]` with just
`Stdlib::HTTPUrl` as that already allows `https` URLs.