### PR TITLE
Better Amazon support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,13 +8,19 @@ class jira::params {
 
   case $facts['osfamily'] {
     /RedHat/: {
-      if versioncmp($facts['operatingsystemmajrelease'], '7') >= 0 {
+      if $facts['operatingsystem'] == 'Amazon' and $facts['operatingsystemmajrelease'] =='2018' {
+        $json_packages = [ 'rubygem-json', 'ruby-json' ]
+        $service_file_location = '/etc/init.d/jira'
+        $service_file_template = 'jira/jira.initscript.erb'
+        $service_lockfile = '/var/lock/subsys/jira'
+        $service_provider = undef
+      } elseif versioncmp($facts['operatingsystemmajrelease'], '7') >= 0 {
         $json_packages = [ 'rubygem-json' ]
         $service_file_location = '/usr/lib/systemd/system/jira.service'
         $service_file_template = 'jira/jira.service.erb'
         $service_lockfile = '/var/lock/subsys/jira'
         $service_provider = 'systemd'
-      } elsif versioncmp($facts['operatingsystemmajrelease'], '6') >= 0 or $facts['operatingsystem'] == 'Amazon' {
+      } elsif versioncmp($facts['operatingsystemmajrelease'], '6') >= 0 {
         $json_packages = [ 'rubygem-json', 'ruby-json' ]
         $service_file_location = '/etc/init.d/jira'
         $service_file_template = 'jira/jira.initscript.erb'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class jira::params {
   case $facts['osfamily'] {
     /RedHat/: {
       if $facts['operatingsystem'] == 'Amazon' and $facts['operatingsystemmajrelease'] =='2018' {
-        $json_packages = [ 'rubygem-json', 'ruby-json' ]
+        $json_packages = [ 'rubygem-json' ]
         $service_file_location = '/etc/init.d/jira'
         $service_file_template = 'jira/jira.initscript.erb'
         $service_lockfile = '/var/lock/subsys/jira'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,7 @@ class jira::params {
         $service_file_template = 'jira/jira.initscript.erb'
         $service_lockfile = '/var/lock/subsys/jira'
         $service_provider = undef
-      } elseif versioncmp($facts['operatingsystemmajrelease'], '7') >= 0 {
+      } elsif versioncmp($facts['operatingsystemmajrelease'], '7') >= 0 {
         $json_packages = [ 'rubygem-json' ]
         $service_file_location = '/usr/lib/systemd/system/jira.service'
         $service_file_template = 'jira/jira.service.erb'


### PR DESCRIPTION
#### Pull Request (PR) description
"if versioncmp($facts['operatingsystemmajrelease'], '7') >= 0" is erroneously true for Amazon Linux 2018 in our observation. I reworked the logic to better test for Amazon Linux vs RHEL/CentOS 6/7.

#### This Pull Request (PR) fixes the following issues
No issue exists for this change.
