### PR TITLE
Jira Service Desk doesn't start with JasperListener / need relaxedPath with correct version comp

### DIFF
--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -32,7 +32,7 @@
     <!--APR library loader. Documentation at /docs/apr.html -->
     <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
     <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener"/>
-<%- if scope.function_versioncmp([@version, '6.4.14']) <= 0 && @product =~ /^jira|servicedesk/ -%>
+<%- if scope.function_versioncmp([@version, '6.4.14']) <= 0 && @product =~ /^jira/ -%>
     <Listener className="org.apache.catalina.core.JasperListener"/>
 <% else -%>
     <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
@@ -58,7 +58,7 @@
                    useBodyEncodingForURI="<%= @tomcat_use_body_encoding_for_uri %>"
                    acceptCount="<%= @tomcat_accept_count %>"
                    disableUploadTimeout="<%= @tomcat_disable_upload_timeout %>"
-                   relaxedPathChars="[]|" 
+                   relaxedPathChars="[]|"
                    relaxedQueryChars="[]|{}^&#x5c;&#x60;&quot;&lt;&gt;"
 <% if @tomcat_native_ssl && @tomcat_redirect_https_port -%>
                    redirectPort="<%= @tomcat_redirect_https_port %>"
@@ -86,7 +86,7 @@
                     enableLookups="<%= @tomcat_enable_lookups %>"
                     disableUploadTimeout="<%= @tomcat_disable_upload_timeout %>"
                     acceptCount="<%= @tomcat_accept_count %>"
-                    relaxedPathChars="[]|" 
+                    relaxedPathChars="[]|"
                     relaxedQueryChars="[]|{}^&#x5c;&#x60;&quot;&lt;&gt;"
 <%   if ! @proxy['scheme'] -%>
                     scheme="https"

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -49,6 +49,10 @@
                    <%- if @tomcat_address -%>
                    address="<%= @tomcat_address %>"
                    <%- end -%>
+                   <%- if ( scope.function_versioncmp([@version, '7.12.1']) > 0 && @product =~ /^jira/ ) or @product =~ /^servicedesk/ -%>
+                   relaxedPathChars="[]|"
+                   relaxedQueryChars="[]|{}^&#x5c;&#x60;&quot;&lt;&gt;"
+                   <%- end -%>
                    maxThreads="<%= @tomcat_max_threads %>"
                    minSpareThreads="<%= @tomcat_min_spare_threads %>"
                    connectionTimeout="<%= @tomcat_connection_timeout %>"
@@ -58,8 +62,6 @@
                    useBodyEncodingForURI="<%= @tomcat_use_body_encoding_for_uri %>"
                    acceptCount="<%= @tomcat_accept_count %>"
                    disableUploadTimeout="<%= @tomcat_disable_upload_timeout %>"
-                   relaxedPathChars="[]|"
-                   relaxedQueryChars="[]|{}^&#x5c;&#x60;&quot;&lt;&gt;"
 <% if @tomcat_native_ssl && @tomcat_redirect_https_port -%>
                    redirectPort="<%= @tomcat_redirect_https_port %>"
 <% else -%>
@@ -79,6 +81,10 @@
                     <%- if @tomcat_address -%>
                     address="<%= @tomcat_address %>"
                     <%- end -%>
+                    <%- if ( scope.function_versioncmp([@version, '7.12.1']) > 0 && @product =~ /^jira/ ) or @product =~ /^servicedesk/ -%>
+                    relaxedPathChars="[]|"
+                    relaxedQueryChars="[]|{}^&#x5c;&#x60;&quot;&lt;&gt;"
+                    <%- end -%>
                     maxHttpHeaderSize="<%= @tomcat_max_http_header_size %>"
                     SSLEnabled="true"
                     maxThreads="<%= @tomcat_max_threads %>"
@@ -86,8 +92,6 @@
                     enableLookups="<%= @tomcat_enable_lookups %>"
                     disableUploadTimeout="<%= @tomcat_disable_upload_timeout %>"
                     acceptCount="<%= @tomcat_accept_count %>"
-                    relaxedPathChars="[]|"
-                    relaxedQueryChars="[]|{}^&#x5c;&#x60;&quot;&lt;&gt;"
 <%   if ! @proxy['scheme'] -%>
                     scheme="https"
 <%   end -%>


### PR DESCRIPTION
#### Pull Request (PR) description
Pull request of #260 (issue #259) wanted to prevent JasperListener to be
activated for Service Desk. Version comp condition can't be fulfilled as
Jira and Service Desk have different version numbers.

Therefore JasperListener gets added to the server.xml anyway with Service Desk. To get Service Desk working we need to adapt the condition to not match when we run Jira Service Desk.

Also relaxedPath options only needed from Jira version >v7.12.1 and Service Desk

(According to https://confluence.atlassian.com/jirakb/changing-server-xml-to-handle-requests-with-special-characters-958453799.html)

We need to have relaxedPathChars and relaxedQueryChars set according to
the FAQ page of Atlassian with Jira version greater than 7.12.1 and
apparently Service Desk.

#### This Pull Request (PR) fixes the following issues
Issue does not exist (yet), relates to issue #259 which doesn't work. Also relaxedPath should only be configured with the correct versions and for Service Desk.
