### PR TITLE
Fix systemd service file mode

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -29,7 +29,10 @@ class jira::service(
 
   file { $service_file_location:
     content => template($service_file_template),
-    mode    => '0755',
+    mode    => $service_provider ? {
+      'systemd' => '0644',
+      default   => '0755',
+    },
   }
 
   if $service_manage {


### PR DESCRIPTION
#### Pull Request (PR) description
On systems with systemd the following warning is logged at every start of JIRA:
"Configuration file /lib/systemd/system/jira.service is marked executable. Please remove executable permission bits. Proceeding anyway.". This is addressed in this PR.

#### This Pull Request (PR) fixes the following issues
Fixes #289