### PR TITLE
Added >= to capture version 7.0.0 as using the "software" url

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -169,7 +169,7 @@ class jira (
   }
 
   # The default Jira product starting with version 7 is 'jira-software'
-  if ((versioncmp($version, '7.0.0') > 0) and ($product == 'jira')) {
+  if ((versioncmp($version, '7.0.0') >= 0) and ($product == 'jira')) {
     $product_name = 'jira-software'
   } else {
     $product_name = $product


### PR DESCRIPTION
#### Pull Request (PR) description
While upgrading JIRA we currently using the recommended path as defined by Atlassian support. Due to issues between versions our final upgrade path was the following. 

```
6.3.10 > 6.3.15 > 6.4.14 > 7.0.0 > 7.0.11 > 7.6.10
```
While installing `7.0.0` the download path was defined incorrectly as the following. 

```
https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-7.0.0-jira-7.0.0.tar.gz
```
While it should be the following (with the software name)
```
https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-7.0.0-jira-7.0.0.tar.gz
```


#### This Pull Request (PR) fixes the following issues
* Added `=` to the case statement that allows for versions `7.0.0` and above, including version `7.0.0` in `init.pp` file. 
