### PR TITLE
Adding ulimit option to setenv.sh environment file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -169,7 +169,7 @@ class jira (
   }
 
   # The default Jira product starting with version 7 is 'jira-software'
-  if ((versioncmp($version, '7.0.0') > 0) and ($product == 'jira')) {
+  if ((versioncmp($version, '7.0.0') >= 0) and ($product == 'jira')) {
     $product_name = 'jira-software'
   } else {
     $product_name = $product

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -95,7 +95,8 @@ class jira (
   # Misc Settings
   Stdlib::HTTPUrl $download_url                                     = 'https://product-downloads.atlassian.com/software/jira/downloads',
   $checksum                                                         = undef,
-  $disable_notifications                                            = false,
+  $disable_notifications,
+  $ulimit                                          = false,
   # Choose whether to use puppet-staging, or puppet-archive
   $deploy_module                                                    = 'archive',
   $proxy_server                                                     = undef,

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -3,7 +3,7 @@
 #
 JIRA_HOME="<%= scope.lookupvar('jira::homedir') %>"
 # ulimit options
-<% if scope.lookupvar('jira::ulimit') -%>
+<% if @jira::ulimit -%>
 ulimit -n "<%= scope.lookupvar('jira::ulimit') %>"
 <% end -%>
 #

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -2,7 +2,10 @@
 # One way to set the JIRA HOME path is here via this variable.  Simply uncomment it and set a valid path like /jira/home.  You can of course set it outside in the command terminal.  That will also work.
 #
 JIRA_HOME="<%= scope.lookupvar('jira::homedir') %>"
-
+# ulimit options
+<% if scope.lookupvar('jira::ulimit') -%>
+ulimit -n "<%= scope.lookupvar('jira::ulimit') %>"
+<% end -%>
 #
 # Additional JAVA_OPTS
 #


### PR DESCRIPTION
#### Pull Request (PR) description
As defined in the [Atlassian knowledge base article](https://confluence.atlassian.com/jirakb/health-check-open-files-limit-838555405.html), Jira can run out of open file resources leading stability issues. The fix is to add the following line for the `setenv.sh` file. 

```
ulimit -n 16384
```

The current `setenv.sh` file does not allow this option and since others may run into this problem, wanted to add this feature into the module. 

#### This Pull Request (PR) fixes the following issues
Adding the variable `ulimit` to allow defining ulimit settings in the `setenv.sh` file from the profile. 
