### PR TITLE
Allow defining additional Tomcat connectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,23 @@ Password to access java keystore. Defaults to 'changeit'
 
 Defaults to 'JKS'. Valid options are 'JKS', 'PKCS12', 'JCEKS'.
 
+##### `$tomcat_additional_connectors`
+
+Well-formed, complex Hash where each key represents a port number and the key's
+value is a hash whose key/value pairs represent the attributes and their values
+that define the connector's behaviour. Default is `{}`.
+
+Use this parameter to specify arbitrary, additional connectors with arbitrary
+attributes. There are no defaults here, so you must take care to specify all
+attributes a connector requires to work in Jira. See below for examples.
+
+This is useful if you need to access your Jira instance directly through an
+additional HTTP port, e.g. one that is not configured for reverse proxy use.
+Atlassian describes use cases for this in
+https://confluence.atlassian.com/kb/how-to-create-an-unproxied-application-link-719095740.html
+and
+https://confluence.atlassian.com/kb/how-to-bypass-a-reverse-proxy-or-ssl-in-application-links-719095724.html
+
 #### Crowd single sign on parameters
 
 #### `enable_sso`
@@ -562,15 +579,53 @@ Some more crowd.properties for SSO, see atlassian documentation for details
 
 ```puppet
     class { 'jira':
-      version      => '6.0.1',
-      installdir   => '/opt/atlassian-jira',
-      homedir      => '/opt/atlassian-jira/jira-home',
-      user         => 'jira',
-      group        => 'jira',
-      dbpassword   => 'secret',
-      dbserver     => 'localhost',
-      javahome     => '/opt/java/jdk1.7.0_21/',
-      download_url => 'http://myserver/pub/development-tools/atlassian/',
+      version                      => '6.0.1',
+      installdir                   => '/opt/atlassian-jira',
+      homedir                      => '/opt/atlassian-jira/jira-home',
+      user                         => 'jira',
+      group                        => 'jira',
+      dbpassword                   => 'secret',
+      dbserver                     => 'localhost',
+      javahome                     => '/opt/java/jdk1.7.0_21/',
+      download_url                 => 'http://myserver/pub/development-tools/atlassian/',
+      tomcat_additional_connectors => {
+        # Define two additional connectors, listening on port 8081 and 8082
+        8081 => {
+          'relaxedPathChars'      => '[]|',
+          'relaxedQueryChars'     => '[]|{}^&#x5c;&#x60;&quot;&lt;&gt;',
+          'maxThreads'            => '150',
+          'minSpareThreads'       => '25',
+          'connectionTimeout'     => '20000',
+          'enableLookups'         => 'false',
+          'maxHttpHeaderSize'     => '8192',
+          'protocol'              => 'HTTP/1.1',
+          'useBodyEncodingForURI' => 'true',
+          'redirectPort'          => '8443',
+          'acceptCount'           => '100',
+          'disableUploadTimeout'  => 'true',
+          'bindOnInit'            => 'false',
+        },
+        # This additional connector is configured for access from a reverse proxy
+        8082 => {
+          'relaxedPathChars'      => '[]|',
+          'relaxedQueryChars'     => '[]|{}^&#x5c;&#x60;&quot;&lt;&gt;',
+          'maxThreads'            => '150',
+          'minSpareThreads'       => '25',
+          'connectionTimeout'     => '20000',
+          'enableLookups'         => 'false',
+          'maxHttpHeaderSize'     => '8192',
+          'protocol'              => 'HTTP/1.1',
+          'useBodyEncodingForURI' => 'true',
+          'redirectPort'          => '8443',
+          'acceptCount'           => '100',
+          'disableUploadTimeout'  => 'true',
+          'bindOnInit'            => 'false',
+          'proxyName'             => 'jira2.example.com',
+          'proxyPort'             => '443',
+          'scheme'                => 'https',
+          'secure'                => true,
+        },
+      }
     }
 ```
 
@@ -611,6 +666,21 @@ jira::proxy:
   proxyName: 'jira.example.co.za'
   proxyPort: '443'
 jira::contextpath: '/jira'
+jira::tomcat_additional_connectors:
+  8181:
+    relaxedPathChars: '[]|'
+    relaxedQueryChars: '[]|{}^&#x5c;&#x60;&quot;&lt;&gt;'
+    maxThreads: '150'
+    minSpareThreads: '25'
+    connectionTimeout: '20000'
+    enableLookups: 'false'
+    maxHttpHeaderSize: '8192'
+    protocol: 'HTTP/1.1'
+    useBodyEncodingForURI: 'true'
+    redirectPort: '8443'
+    acceptCount: '100'
+    disableUploadTimeout: 'true'
+    bindOnInit: 'false'
 ```
 
 These additional and substituted parameters are used in production in an

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -141,6 +141,8 @@ class jira (
   Hash $proxy                                                       = {},
   # Options for the AJP connector
   Hash $ajp                                                         = {},
+  # Additional connectors in server.xml
+  Jira::Tomcat_connectors $tomcat_additional_connectors             = {},
   # Context path (usualy used in combination with a reverse proxy)
   String $contextpath                                               = '',
   # Resources for context.xml

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -401,6 +401,53 @@ describe 'jira' do
             end
           end
 
+          context 'tomcat additional connectors' do
+            let(:params) do
+              {
+                version: '6.3.4a',
+                javahome: '/opt/java',
+                tomcat_additional_connectors: {
+                  8081 => {
+                    'URIEncoding' => 'UTF-8',
+                    'connectionTimeout' => '20000',
+                    'protocol' => 'HTTP/1.1',
+                    'proxyName' => 'foo.example.com',
+                    'proxyPort' => '8123',
+                    'secure' => true,
+                    'scheme' => 'https'
+                  },
+                  8082 => {
+                    'URIEncoding' => 'UTF-8',
+                    'connectionTimeout' => '20000',
+                    'protocol' => 'HTTP/1.1',
+                    'proxyName' => 'bar.example.com',
+                    'proxyPort' => '8124',
+                    'scheme' => 'http'
+                  }
+                }
+              }
+            end
+
+            it do
+              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+                with_content(%r{<Connector port="8081"}).
+                with_content(%r{connectionTimeout="20000"}).
+                with_content(%r{protocol="HTTP/1\.1"}).
+                with_content(%r{proxyName="foo\.example\.com"}).
+                with_content(%r{proxyPort="8123"}).
+                with_content(%r{scheme="https"}).
+                with_content(%r{secure="true"}).
+                with_content(%r{URIEncoding="UTF-8"}).
+                with_content(%r{<Connector port="8082"}).
+                with_content(%r{connectionTimeout="20000"}).
+                with_content(%r{protocol="HTTP/1\.1"}).
+                with_content(%r{proxyName="bar\.example\.com"}).
+                with_content(%r{proxyPort="8124"}).
+                with_content(%r{scheme="http"}).
+                with_content(%r{URIEncoding="UTF-8"})
+            end
+          end
+
           context 'tomcat access log format' do
             let(:params) do
               {

--- a/spec/type_aliases/tomcat_attributes_spec.rb
+++ b/spec/type_aliases/tomcat_attributes_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe 'Jira::Tomcat_attributes' do
+  describe 'valid attributes' do
+    [
+      { 'URIEncoding' => 'UTF-8' },
+      { 'secure' => true },
+      { 'proxyPort' => 8443 },
+      {
+        'URIEncoding' => 'UTF-8',
+        'connectionTimeout' => '20000',
+        'protocol' => 'HTTP/1.1',
+        'proxyName' => 'foo.example.com',
+        'proxyPort' => '8123',
+        'secure' => true,
+        'scheme' => 'https'
+      },
+      {}
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.to allow_value(value) }
+      end
+    end
+  end
+
+  describe 'invalid attributes' do
+    context 'with garbage inputs' do
+      [
+        { %w[foo blah] => 'bar' },
+        { true => 'false' },
+        { 'proxyPort' => %w[8443 1234] },
+        { 'schema' => { 'https' => 'false' } },
+        true,
+        false,
+        :keyword,
+        nil,
+        %w[yes no],
+        '',
+        'ネット',
+        '55555',
+        '0x123',
+        'yess',
+        'nooo'
+      ].each do |value|
+        describe value.inspect do
+          it { is_expected.not_to allow_value(value) }
+        end
+      end
+    end
+  end
+end

--- a/spec/type_aliases/tomcat_connectors_spec.rb
+++ b/spec/type_aliases/tomcat_connectors_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+describe 'Jira::Tomcat_connectors' do
+  describe 'valid connector specifications' do
+    [
+      {
+        8081 => {
+          'URIEncoding' => 'UTF-8',
+          'connectionTimeout' => '20000',
+          'protocol' => 'HTTP/1.1',
+          'proxyName' => 'foo.example.com',
+          'proxyPort' => '80',
+          'secure' => false,
+          'scheme' => 'http'
+        },
+        8443 => {
+          'URIEncoding' => 'UTF-8',
+          'connectionTimeout' => '20000',
+          'protocol' => 'HTTP/1.1',
+          'proxyName' => 'foo.example.com',
+          'proxyPort' => '443',
+          'secure' => true,
+          'scheme' => 'https'
+        }
+      }
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.to allow_value(value) }
+      end
+    end
+  end
+
+  describe 'invalid connector specifications' do
+    context 'with garbage inputs' do
+      [
+        {
+          '8081' => {
+            'URIEncoding' => 'UTF-8',
+            'connectionTimeout' => '20000',
+            'protocol' => 'HTTP/1.1',
+            'proxyName' => 'foo.example.com',
+            'proxyPort' => '80',
+            'secure' => false,
+            'scheme' => 'http'
+          }
+        },
+        {
+          1023 => {
+            'URIEncoding' => 'UTF-8',
+            'connectionTimeout' => '20000',
+            'protocol' => 'HTTP/1.1',
+            'proxyName' => 'foo.example.com',
+            'proxyPort' => '80',
+            'secure' => false,
+            'scheme' => 'http'
+          }
+        },
+        { %w[foo blah] => 'bar' },
+        { true => 'false' },
+        { 'proxyPort' => %w[8443 1234] },
+        { 'schema' => { 'https' => 'false' } },
+        true,
+        false,
+        :keyword,
+        nil,
+        %w[yes no],
+        '',
+        'ネット',
+        '55555',
+        '0x123',
+        'yess',
+        'nooo'
+      ].each do |value|
+        describe value.inspect do
+          it { is_expected.not_to allow_value(value) }
+        end
+      end
+    end
+  end
+end

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -119,6 +119,15 @@
         />
 <% end -%>
 
+<% if @tomcat_additional_connectors and ! @tomcat_additional_connectors.empty? -%>
+<% @tomcat_additional_connectors.sort.map do |port, attrs| -%>
+        <Connector port="<%= port -%>"
+<% attrs.sort.map do |key, value| -%>
+                   <%= key -%>="<%= value -%>"
+<% end -%>
+                   />
+<% end -%>
+<% end -%>
         <Engine name="Catalina" defaultHost="localhost">
             <Host name="localhost" appBase="webapps" unpackWARs="true" autoDeploy="true">
 

--- a/types/tomcat_attributes.pp
+++ b/types/tomcat_attributes.pp
@@ -1,0 +1,1 @@
+type Jira::Tomcat_attributes = Hash[String[1], Scalar]

--- a/types/tomcat_connectors.pp
+++ b/types/tomcat_connectors.pp
@@ -1,0 +1,1 @@
+type Jira::Tomcat_connectors = Hash[Stdlib::Port::Unprivileged, Jira::Tomcat_attributes]


### PR DESCRIPTION
#### Pull Request (PR) description

Add a new, optional class parameter `jira::tomcat_additional_connectors`
whose value is a well-formed, complex hash as described by the new type
aliases `Jira::Tomcat_connectors` and `Jira::Tomcat_attributes`. Each
hash key represents a port number, and the key's value is a hash that
describes the connector's attributes and their values.

Useful for defining additional HTTP ports through which to access Jira.
A typical use case is when Jira and Confluence run behind a reverse
proxy and application links between Jira and Confluence must be set up.
Then it is often better to allow Jira and Confluence to communicate
directly instead of through the reverse proxy, but this requires a
Tomcat connector that is configured for direct access instead of reverse
proxy access (`proxyName`, `proxyPort`, etc). Described here:
https://confluence.atlassian.com/kb/how-to-create-an-unproxied-application-link-719095740.html

Contains spec tests, documentation and examples.