### PR TITLE
Update jira::facts to check for Puppet AIO agent

### DIFF
--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -32,6 +32,9 @@ class jira::facts (
   if $facts['puppetversion'] =~ /Puppet Enterprise/ {
     $ruby_bin = '/opt/puppet/bin/ruby'
     $dir = 'puppetlabs/'
+  } elsif $facts['aio_agent_version'] =~ String[1] {
+    $ruby_bin = '/opt/puppetlabs/puppet/bin/ruby'
+    $dir      = ''
   } else {
     $ruby_bin = '/usr/bin/env ruby'
     $dir = ''

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -34,7 +34,7 @@ class jira::facts (
     $dir = 'puppetlabs/'
   } elsif $facts['aio_agent_version'] =~ String[1] {
     $ruby_bin = '/opt/puppetlabs/puppet/bin/ruby'
-    $dir      = ''
+    $dir      = 'puppetlabs/'
   } else {
     $ruby_bin = '/usr/bin/env ruby'
     $dir = ''

--- a/spec/classes/jira_facts_spec.rb
+++ b/spec/classes/jira_facts_spec.rb
@@ -12,7 +12,7 @@ describe 'jira::facts' do
         regexp_oss = %r{^#\!/opt/puppetlabs/puppet/bin/ruby$}
         regexp_url = %r{http://127.0.0.1\:8080/rest/api/2/serverInfo}
         pe_external_fact_file = '/etc/puppetlabs/facter/facts.d/jira_facts.rb'
-        external_fact_file = '/etc/facter/facts.d/jira_facts.rb'
+        external_fact_file = '/etc/puppetlabs/facter/facts.d/jira_facts.rb'
 
         it { is_expected.to contain_file(external_fact_file) }
         it { is_expected.to compile.with_all_deps }

--- a/spec/classes/jira_facts_spec.rb
+++ b/spec/classes/jira_facts_spec.rb
@@ -9,7 +9,7 @@ describe 'jira::facts' do
         let(:pre_condition) { "class{'::jira': javahome => '/opt/java'}" }
 
         regexp_pe = %r{^#\!/opt/puppet/bin/ruby$}
-        regexp_oss = %r{^#\!/usr/bin/env ruby$}
+        regexp_oss = %r{^#\!/opt/puppetlabs/puppet/bin/ruby$}
         regexp_url = %r{http://127.0.0.1\:8080/rest/api/2/serverInfo}
         pe_external_fact_file = '/etc/puppetlabs/facter/facts.d/jira_facts.rb'
         external_fact_file = '/etc/facter/facts.d/jira_facts.rb'


### PR DESCRIPTION
#### Pull Request (PR) description

Updates `jira::facts` to check for the OSS version of the Puppet AIO agent. If the OSS Puppet AIO agent is installed it will set `facts.rb` to use the version of ruby that comes with the AIO agent.

#### This Pull Request (PR) fixes the following issues

Fixes #151