### PR TITLE
Feature/east 2418

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,6 +76,7 @@ class jira (
   $pool_min_size                                                    = 20,
   $pool_max_size                                                    = 20,
   $pool_max_wait                                                    = 30000,
+  $connection_properties                                            = 'defaultRowPrefetch=200',
   $validation_query                                                 = undef,
   $min_evictable_idle_time                                          = 60000,
   $time_between_eviction_runs                                       = undef,
@@ -133,7 +134,7 @@ class jira (
   Stdlib::Absolutepath $tomcat_keystore_file                        = '/home/jira/jira.jks',
   $tomcat_keystore_pass                                             = 'changeit',
   Enum['JKS', 'JCEKS', 'PKCS12'] $tomcat_keystore_type              = 'JKS',
-  $tomcat_accesslog_format                                          = '%a %{jira.request.id}r %{jira.request.username}r %t &quot;%m %U%q %H&quot; %s %b %D &quot;%{Referer}i&quot; &quot;%{User-Agent}i&quot; &quot;%{jira.request.assession.id}r&quot;',
+  $tomcat_accesslog_format                                          = '%a %{jira.request.id}r %{jira.request.username}r %t &I &quot;%m %U%q %H&quot; %s %b %D &quot;%{Referer}i&quot; &quot;%{User-Agent}i&quot; &quot;%{jira.request.assession.id}r&quot;',
   # Tomcat Tunables
   $tomcat_max_threads                                               = '150',
   $tomcat_accept_count                                              = '100',

--- a/templates/dbconfig.oracle.xml.erb
+++ b/templates/dbconfig.oracle.xml.erb
@@ -13,6 +13,7 @@
     <pool-max-size><%= scope.lookupvar('jira::pool_max_size') %></pool-max-size>
     <pool-max-wait><%= scope.lookupvar('jira::pool_max_wait') %></pool-max-wait>
     <pool-max-idle><%= scope.lookupvar('jira::pool_max_idle') %></pool-max-idle>
+    <connection-properties><%= scope.lookupvar('jira::connection_properties') %></connection-properties>
     <pool-remove-abandoned><%= scope.lookupvar('jira::pool_remove_abandoned') %></pool-remove-abandoned>
     <pool-remove-abandoned-timeout><%= scope.lookupvar('jira::pool_remove_abandoned_timeout') %></pool-remove-abandoned-timeout>
     <validation-query><% if @validation_query %><%= @validation_query %><% else %>scope.lookupvar('jira::validation_query')<% end %></validation-query>


### PR DESCRIPTION


NOTE: we could leave the connection_properties value 'undef' and pass it via Hiera config for each evn as well.

**Update dbconfig.xml**
Adding the following to the <jdbc-datasource> section in the dbconfig.xml file:

<connection-properties>defaultRowPrefetch=200</connection-properties>

What this does is change the default value (10) to 200. It helps with sprint operations performance when there is a large number of sprints.

Please check for more details: https://jira.atlassian.com/browse/JSWSERVER-20618.

**Add thread name to access logs:**


Adding the "%I" (uppercase i) parameter to the Access Log valve in <jira-installation>/atlassian-jira/conf/server.xml.
Example:

<Valve className="org.apache.catalina.valves.AccessLogValve"                   pattern="%a %{jira.request.id}r %{jira.request.username}r %t %I "%m %U%q %H" %s %b %D "%{Referer}i" "%{User-Agent}i" "%{jira.request.assession.id}r""/>

