### PR TITLE
Adapting templates to state of 8.7.1 tarball, while keeping required …

### DIFF
--- a/templates/check-java.sh.erb
+++ b/templates/check-java.sh.erb
@@ -1,26 +1,58 @@
 #!/bin/sh
 # This file is managed by Puppet
 
-# This file should be identical to 'check-java.sh' in the Jira 7.0.4 standalone
+# This file should be identical to 'check-java.sh' in the Jira 8.7.1 standalone
 # tarball.
-
-_EXPECTED_JAVA_VERSION="8"
 
 #
 # check for correct java version by parsing out put of java -version
-# we expect first line to be in format 'java version "1.8.0_40"' and assert that minor version number will be 8 or higher
+# we expect first line to be in format 'java version "1.8.0_161"' or 'java version "10.0.1" 2018-04-17'
+# or 'openjdk version "11-ea" 2018-09-25' and assert that version number will be 8 or 11 (if enabled)
+# or sth like 'Picked up JDK_JAVA_OPTIONS:' (which we need to skip)
 #
 
-"$_RUNJAVA" -version 2>&1 | grep "java version" | (
-        IFS=. read ignore1 version ignore2
-        if [ ! ${version:-0} -ge "$_EXPECTED_JAVA_VERSION" ]
-        then
-           echo "*************************************************************************************************************************************"
-           echo "**********     Wrong JVM version! You are running with "$ignore1"."$version"."$ignore2" but JIRA requires at least 1.8 to run.      **********"
-           echo "*************************************************************************************************************************************"
-           exit 1
-        fi
-    )
-if [ $? -ne 0 ] ; then
-   exit 1
+java_raw_version=`echo "$($_RUNJAVA -version 2>&1)" | grep -v "JDK_JAVA_OPTIONS" | grep "version" | awk '{ print substr($3, 2, length($3)-2); }'`
+java_version=0
+
+if [[ $java_raw_version = *-ea* ]]
+then
+	# early access format e.g 11-ea
+    IFS='-' read -a values <<< "$java_raw_version"
+    java_version=${values[0]}
+else
+	if [[ $java_raw_version = 1.* ]]
+	then
+		# old format e.g. 1.8.0_161
+	    IFS='.' read -a values <<< "$java_raw_version"
+		java_version=${values[1]}
+	else
+		# new format e.g. 10.0.1
+		IFS='.' read -a values <<< "$java_raw_version"
+		java_version=${values[0]}
+	fi
+fi
+
+if [ $java_version -ne 8 ] && [ $java_version -ne 11 ]
+then
+    echo "****************************************************************************"
+    echo "*******      Wrong JVM version! Jira requires 1.8 or 11 to run.      *******"
+    echo "****************************************************************************"
+    echo "***"
+    echo "*** Output of java -version command is:"
+    $_RUNJAVA -version 2>&1
+    echo "*** (End of output) ***"
+    echo "***"
+    if [ "$ignore_jvm_version" = "true" ]
+    then
+        echo "*** Environment variable 'ignore_jvm_version' is set to 'true'"
+        echo "*** Jira is going to bypass restriction and run using existing JVM version"
+        echo "***"
+        echo "****************************************************************************"
+    else
+        echo "*** If you want Jira to start using this JVM"
+        echo "*** set environment variable 'ignore_jvm_version' to 'true'"
+        echo "***"
+        echo "****************************************************************************"
+        exit 1
+    fi
 fi

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -1,16 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-   ====================================================================================
 
-   Atlassian JIRA Standalone Edition Tomcat Configuration.
-
-
-   See the following for more information
-
-   http://confluence.atlassian.com/display/JIRA/Configuring+JIRA+Standalone
-
-   ====================================================================================
- -->
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -28,21 +17,14 @@
   limitations under the License.
 -->
 <Server port="<%= @tomcat_shutdown_port %>" shutdown="SHUTDOWN">
-
-    <!--APR library loader. Documentation at /docs/apr.html -->
     <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+    <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener"/>
     <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener"/>
 <%- if scope.function_versioncmp([@version, '6.4.14']) <= 0 && @product =~ /^jira/ -%>
     <Listener className="org.apache.catalina.core.JasperListener"/>
 <% else -%>
     <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
 <%- end -%>
-    <!-- Security listener. Documentation at /docs/config/listeners.html
-    <Listener className="org.apache.catalina.security.SecurityListener" />
-    -->
-    <!-- Prevent memory leaks due to use of particular java/javax APIs-->
-    <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
-    <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
 
     <Service name="Catalina">
         <Connector port="<%= @tomcat_port %>"
@@ -62,6 +44,7 @@
                    useBodyEncodingForURI="<%= @tomcat_use_body_encoding_for_uri %>"
                    acceptCount="<%= @tomcat_accept_count %>"
                    disableUploadTimeout="<%= @tomcat_disable_upload_timeout %>"
+                   bindOnInit="false"
 <% if @tomcat_native_ssl && @tomcat_redirect_https_port -%>
                    redirectPort="<%= @tomcat_redirect_https_port %>"
 <% else -%>
@@ -128,6 +111,7 @@
                               factory="org.objectweb.jotm.UserTransactionFactory" jotm.timeout="60"/>
                     <Manager pathname=""/>
                     <JarScanner scanManifest="false"/>
+                    <Valve className="org.apache.catalina.valves.StuckThreadDetectionValve" threshold="120" />
                 </Context>
 
             </Host>

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -1,4 +1,9 @@
 #
+# If the limit of files that Jira can open is too low, it will be set to this value.
+#
+MIN_NOFILES_LIMIT=16384
+
+#
 # One way to set the JIRA HOME path is here via this variable.  Simply uncomment it and set a valid path like /jira/home.  You can of course set it outside in the command terminal.  That will also work.
 #
 JIRA_HOME="<%= scope.lookupvar('jira::homedir') %>"
@@ -18,16 +23,28 @@ CATALINA_OPTS="<%= scope.lookupvar('jira::catalina_opts') %> $CATALINA_OPTS"
 JVM_SUPPORT_RECOMMENDED_ARGS="<%= scope.lookupvar('jira::jvm_optional') %>"
 
 #
+#  You can use variable below to modify garbage collector settings.
+#  For Java 8 we recommend default settings
+#  For Java 11 and relatively small heaps we recommend: -XX:+UseParallelGC
+#  For Java 11 and larger heaps we recommend: -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent
+#
+JVM_GC_ARGS="-XX:+ExplicitGCInvokesConcurrent"
+
+#
 # The following 2 settings control the minimum and maximum given to the JIRA Java virtual machine.  In larger JIRA instances, the maximum amount will need to be increased.
 #
 JVM_MINIMUM_MEMORY="<%= scope.lookupvar('jira::jvm_xms') %>"
 JVM_MAXIMUM_MEMORY="<%= scope.lookupvar('jira::jvm_xmx') %>"
-JVM_PERMGEN_MEMORY="<%= scope.lookupvar('jira::jvm_permgen') %>"
+
+#
+# The following setting configures the size of JVM code cache.  A high value of reserved size allows Jira to work with more installed apps.
+#
+JVM_CODE_CACHE_ARGS='-XX:InitialCodeCacheSize=32m -XX:ReservedCodeCacheSize=512m'
 
 #
 # The following are the required arguments for JIRA.
 #
-JVM_REQUIRED_ARGS="-Djava.awt.headless=true -Datlassian.standalone=JIRA -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true -Dmail.mime.decodeparameters=true"
+JVM_REQUIRED_ARGS='-Djava.awt.headless=true -Datlassian.standalone=JIRA -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true -Dmail.mime.decodeparameters=true -Dorg.dom4j.factory=com.atlassian.core.xml.InterningDocumentFactory'
 
 # Uncomment this setting if you want to import data without notifications
 #
@@ -44,10 +61,14 @@ DISABLE_NOTIFICATIONS=" -Datlassian.mail.senddisabled=true -Datlassian.mail.fetc
 #-----------------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------------
-# This allows us to actually debug GC related issues by correlating timestamps
-# with other parts of the application logs.
+# Prevents the JVM from suppressing stack traces if a given type of exception
+# occurs frequently, which could make it harder for support to diagnose a problem.
 #-----------------------------------------------------------------------------------
-JVM_EXTRA_ARGS="-XX:+PrintGCDateStamps"
+JVM_EXTRA_ARGS="-XX:-OmitStackTraceInFastThrow -Djava.locale.providers=COMPAT"
+
+CURRENT_NOFILES_LIMIT=$( ulimit -Hn )
+ulimit -Sn $CURRENT_NOFILES_LIMIT
+ulimit -n $(( CURRENT_NOFILES_LIMIT > MIN_NOFILES_LIMIT  ? CURRENT_NOFILES_LIMIT : MIN_NOFILES_LIMIT ))
 
 PRGDIR=`dirname "$0"`
 cat "${PRGDIR}"/jirabanner.txt
@@ -65,25 +86,15 @@ if [ "$JIRA_HOME" != "" ]; then
     fi
 fi
 
-JAVA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} ${JAVA_OPTS} ${JVM_REQUIRED_ARGS} ${DISABLE_NOTIFICATIONS} ${JVM_SUPPORT_RECOMMENDED_ARGS} ${JVM_EXTRA_ARGS} ${JIRA_HOME_MINUSD}"
-
-# Perm Gen size needs to be increased if encountering OutOfMemoryError: PermGen problems. Specifying PermGen size is not valid on IBM JDKs
-JIRA_MAX_PERM_SIZE=${JVM_PERMGEN_MEMORY}
-if [ -f "${PRGDIR}/permgen.sh" ]; then
-    echo "Detecting JVM PermGen support..."
-    . "${PRGDIR}/permgen.sh"
-    if [ $JAVA_PERMGEN_SUPPORTED = "true" ]; then
-        echo "PermGen switch is supported. Setting to ${JIRA_MAX_PERM_SIZE}"
-        JAVA_OPTS="-XX:MaxPermSize=${JIRA_MAX_PERM_SIZE} ${JAVA_OPTS}"
-    else
-        echo "PermGen switch is NOT supported and will NOT be set automatically."
-    fi
-fi
+JAVA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} ${JVM_CODE_CACHE_ARGS} ${JAVA_OPTS} ${JVM_REQUIRED_ARGS} ${DISABLE_NOTIFICATIONS} ${JVM_SUPPORT_RECOMMENDED_ARGS} ${JVM_EXTRA_ARGS} ${JIRA_HOME_MINUSD} ${START_JIRA_JAVA_OPTS}"
 
 export JAVA_OPTS CATALINA_OPTS
 
+# DO NOT remove the following line
+# !INSTALLER SET JAVA_HOME
+
 echo ""
-echo "If you encounter issues starting or stopping JIRA, please see the Troubleshooting guide at http://confluence.atlassian.com/display/JIRA/Installation+Troubleshooting+Guide"
+echo "If you encounter issues starting or stopping Jira, please see the Troubleshooting guide at https://docs.atlassian.com/jira/jadm-docs-087/Troubleshooting+installation"
 echo ""
 if [ "$JIRA_HOME_MINUSD" != "" ]; then
     echo "Using JIRA_HOME:       $JIRA_HOME"


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This adapts the templates for java-check, server.xml and setenv to the state of the 8.7.1 tarball, while keeping required modifications in place.

I thought about setting stuff depending on the installed java version, however not everyone installs java also via puppet and if ones does it, it must not necessarily be via the java puppet module.
Maybe we need an additional parameter to the module stating the java version?

#### This Pull Request (PR) fixes the following issues
Fixes #300

