### PR TITLE
remove incorrect apostrophe in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,7 +644,7 @@ jira::group:         'jira'
 jira::shell:         '/bin/bash'
 jira::dbserver:      'dbvip.example.co.za'
 jira::javahome:      '/opt/java'
-jira::java_opts: >
+jira::java_opts: >-
   -Dhttp.proxyHost=proxy.example.co.za
   -Dhttp.proxyPort=8080
   -Dhttps.proxyHost=proxy.example.co.za

--- a/README.md
+++ b/README.md
@@ -650,7 +650,7 @@ jira::java_opts: >
   -Dhttps.proxyHost=proxy.example.co.za
   -Dhttps.proxyPort=8080
   -Dhttp.nonProxyHosts=localhost\|127.0.0.1\|172.*.*.*\|10.*.*.*
-  -XX:+UseLargePages'
+  -XX:+UseLargePages
 jira::dbport:        '5439'
 jira::dbuser:        'jira'
 jira::jvm_xms:       '1G'


### PR DESCRIPTION
this yaml code for jira::java_opts with incorrect apostrophe generates with the template `JAVA_OPTS="<%= scope.lookupvar('jira::java_opts') %> $JAVA_OPTS"` incorrect code 
```
JAVA_OPTS="-Datlassian.mail.senddisabled=true -Datlassian.mail.fetchdisabled=true -Datlassian.mail.popdisabled=true'
 $JAVA_OPTS"
```
which generates then error
```
/opt/jira/atlassian-jira-software-8.13.0-standalone/bin/catalina.sh: eval: line 517: unexpected EOF while looking for matching `''
/opt/jira/atlassian-jira-software-8.13.0-standalone/bin/catalina.sh: eval: line 519: syntax error: unexpected end of file
```
In fact, without apostrophe, it still generates linebreak in `JAVA_OPTS`, and then jira does not start. I will create ticket for this issue.