### PR TITLE
Fix MySQL Connector directory permissions

### DIFF
--- a/manifests/mysql_connector.pp
+++ b/manifests/mysql_connector.pp
@@ -15,6 +15,7 @@ class jira::mysql_connector (
       ensure => 'directory',
       owner  => root,
       group  => root,
+      mode   => '0755',
       before => Staging::File[$file],
     }
   }


### PR DESCRIPTION
#### Pull Request (PR) description
Set the directory permissions of the MySQL Connector directory so users other than root can use the connector.

#### This Pull Request (PR) fixes the following issues
Fixes #241 

