### PR TITLE
Drop EoL CentOS 6 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,13 +21,6 @@ class jira::params {
         $service_file_mode     = '0644'
         $service_lockfile      = '/var/lock/subsys/jira'
         $service_provider      = 'systemd'
-      } elsif versioncmp($facts['os']['release']['major'], '6') >= 0 {
-        $json_packages         = ['rubygem-json', 'ruby-json']
-        $service_file_location = '/etc/init.d/jira'
-        $service_file_template = 'jira/jira.initscript.erb'
-        $service_file_mode     = '0755'
-        $service_lockfile      = '/var/lock/subsys/jira'
-        $service_provider      = undef
       } else {
       fail("\"${module_name}\" provides no service parameters
             for \"${facts['os']['family']}\" - \"${$facts['os']['release']['major']}\"")

--- a/metadata.json
+++ b/metadata.json
@@ -35,28 +35,24 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },


### PR DESCRIPTION
CentOS 6 is not supported anymore. Our tests do not run on this
platform. They failed even before they reordered their mirrors, we just
didn't test on it. To unblock open PRs, this PR drops support for it.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
