### PR TITLE
Fixing that the suffix can be empty as well (needed for mysql-connector > 8)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,7 +71,6 @@ class jira (
   $mysql_connector_format                                           = 'tar.gz',
   Stdlib::Absolutepath $mysql_connector_install                     = '/opt/MySQL-connector',
   Stdlib::HTTPUrl $mysql_connector_url                              = 'https://dev.mysql.com/get/Downloads/Connector-J',
-  String[1] $mysql_connector_jar_suffix                             = '-bin',
   # Configure database settings if you are pooling connections
   $enable_connection_pooling                                        = false,
   $pool_min_size                                                    = 20,

--- a/manifests/mysql_connector.pp
+++ b/manifests/mysql_connector.pp
@@ -4,8 +4,7 @@ class jira::mysql_connector (
   $product      = $jira::mysql_connector_product,
   $format       = $jira::mysql_connector_format,
   $installdir   = $jira::mysql_connector_install,
-  $download_url = $jira::mysql_connector_url,
-  $jar_suffix   = $jira::mysql_connector_jar_suffix,
+  $download_url = $jira::mysql_connector_url
 ) {
   require staging
 
@@ -20,6 +19,12 @@ class jira::mysql_connector (
     }
   }
 
+  if (versioncmp($jira::mysql_connector_version, '8.0.0') == -1) { # version < 8.0.0
+    $jarfile = "${product}-${version}-bin.jar"
+  } else {
+    $jarfile = "${product}-${version}.jar"
+  }
+
   staging::file { $file:
     source  => "${download_url}/${file}",
     timeout => 300,
@@ -32,6 +37,6 @@ class jira::mysql_connector (
 
   -> file { "${jira::webappdir}/lib/mysql-connector-java.jar":
     ensure => link,
-    target => "${installdir}/${product}-${version}/${product}-${version}${jar_suffix}.jar",
+    target => "${installdir}/${product}-${version}/${jarfile}",
   }
 }

--- a/spec/classes/jira_mysql_connector_spec.rb
+++ b/spec/classes/jira_mysql_connector_spec.rb
@@ -34,6 +34,31 @@ describe 'jira' do
                                                                                                  'creates' => '/opt/MySQL-connector/mysql-connector-java-5.1.34')
             end
           end
+          context 'mysql connector defaults Connector Version >8' do
+            let(:params) do
+              {
+                version: '6.3.4a',
+                javahome: '/opt/java',
+                db: 'mysql',
+                mysql_connector_version: '8.0.23'
+              }
+            end
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_file('/opt/MySQL-connector').with_ensure('directory') }
+            it do
+              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/lib/mysql-connector-java.jar').
+                with(
+                  'ensure' => 'link',
+                  'target' => '/opt/MySQL-connector/mysql-connector-java-8.0.23/mysql-connector-java-8.0.23.jar'
+                )
+            end
+            it 'deploys mysql connector 8.0.23 from tar.gz' do
+              is_expected.to contain_staging__file('mysql-connector-java-8.0.23.tar.gz').with('source' => 'https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-8.0.23.tar.gz')
+              is_expected.to contain_staging__extract('mysql-connector-java-8.0.23.tar.gz').with('target' => '/opt/MySQL-connector',
+                                                                                                 'creates' => '/opt/MySQL-connector/mysql-connector-java-8.0.23')
+            end
+          end
           context 'mysql connector overwrite params' do
             let(:params) do
               {

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -82,7 +82,10 @@ DISABLE_NOTIFICATIONS='-Datlassian.mail.senddisabled=true -Datlassian.mail.fetch
 # occurs frequently, which could make it harder for support to diagnose a problem.
 #-----------------------------------------------------------------------------------
 <%- if @jvm_type == 'openjdk-11' -%>
-JVM_EXTRA_ARGS='-Xlog:gc*:verbose_gc.log:time,uptime:filecount=15,filesize=10M -XX:+ExplicitGCInvokesConcurrent -XX:-OmitStackTraceInFastThrow -Djava.locale.providers=COMPAT <%= @jvm_extra_args_additional %>'
+JVM_EXTRA_ARGS='<%= @jvm_extra_args_additional %>'
+JVM_EXTRA_ARGS+="-Xlog:gc*:${CATALINA_HOME}/logs/verbose_gc.log:time,uptime:filecount=15,filesize=10M"
+JVM_EXTRA_ARGS+=' '
+JVM_EXTRA_ARGS+='-XX:+ExplicitGCInvokesConcurrent -XX:-OmitStackTraceInFastThrow -Djava.locale.providers=COMPAT'
 <%- elsif @jvm_type == 'oracle-jdk-1.8' -%>
 JVM_EXTRA_ARGS='-XX:+PrintGCDateStamps -XX:+ExplicitGCInvokesConcurrent -XX:-OmitStackTraceInFastThrow -Djava.locale.providers=COMPAT <%= @jvm_extra_args_additional %>'
 <%- elsif @jvm_type == 'custom' -%>


### PR DESCRIPTION
#### Pull Request (PR) description
The change is needed to specificy and use a mysql-connector version > 8. The problem with those connectors is, that there is no "-bin" suffix in the jarfile and therefore the suffix needs to be empty. As the current String will require the string to be at least 1 character long, a version 8 connector can not be configured.

```
class {'jira':
...
    mysql_connector_manage       => true,
    mysql_connector_version      => '8.0.23',
    mysql_connector_install      => '/opt/MySQL-connector',
    mysql_connector_url          => 'https://dev.mysql.com/get/Downloads/Connector-J',
    mysql_connector_jar_suffix   => '', # no '-bin'!
...
```
results in 
Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Class[Jira]: parameter 'mysql_connector_jar_suffix' expects a String[1, default]

#### This Pull Request (PR) fixes the following issues
Enables the useage of mysql-connector version > 8
