### PR TITLE
facts.pp: use localhost instead of 127.0.0.1

### DIFF
--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -19,12 +19,7 @@ class jira::facts (
   $port          = $jira::tomcat_port,
   $contextpath   = $jira::contextpath,
   $json_packages = $jira::params::json_packages,
-  # lint:ignore:parameter_order
-  $uri           = $jira::tomcat_address ? {
-    undef   => 'localhost',
-    default => $jira::tomcat_address,
-  },
-  # lint:endignore
+  $uri           = pick($jira::tomcat_address, 'localhost')
 ) inherits jira::params {
   if $facts['aio_agent_version'] =~ String[1] {
     $ruby_bin = '/opt/puppetlabs/puppet/bin/ruby'

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -21,7 +21,7 @@ class jira::facts (
   $json_packages = $jira::params::json_packages,
   # lint:ignore:parameter_order
   $uri           = $jira::tomcat_address ? {
-    undef   => '127.0.0.1',
+    undef   => 'localhost',
     default => $jira::tomcat_address,
   },
   # lint:endignore

--- a/spec/classes/jira_facts_spec.rb
+++ b/spec/classes/jira_facts_spec.rb
@@ -18,7 +18,7 @@ describe 'jira::facts' do
           it do
             is_expected.to contain_file('/etc/puppetlabs/facter/facts.d/jira_facts.rb'). \
               with_content(%r{#!/opt/puppetlabs/puppet/bin/ruby}).
-              with_content(%r{http://127\.0\.0\.1:8080/rest/api/2/serverInfo})
+              with_content(%r{http://localhost:8080/rest/api/2/serverInfo})
           end
 
           it { is_expected.not_to contain_file('/etc/facter/facts.d/jira_facts.rb') }
@@ -36,7 +36,7 @@ describe 'jira::facts' do
           it do
             is_expected.to contain_file('/etc/facter/facts.d/jira_facts.rb'). \
               with_content(%r{#!/usr/bin/env ruby}).
-              with_content(%r{http://127\.0\.0\.1:8080/rest/api/2/serverInfo})
+              with_content(%r{http://localhost:8080/rest/api/2/serverInfo})
           end
 
           case facts[:osfamily]
@@ -54,7 +54,7 @@ describe 'jira::facts' do
 
           it do
             is_expected.to contain_file('/etc/puppetlabs/facter/facts.d/jira_facts.rb'). \
-              with_content(%r{  url = 'http://127.0.0.1:8080/jira})
+              with_content(%r{  url = 'http://localhost:8080/jira})
           end
         end
       end

--- a/templates/facts.rb.erb
+++ b/templates/facts.rb.erb
@@ -1,5 +1,5 @@
 #!<%= @ruby_bin %>
-# Facts: 
+# Facts:
 #   - jira_buildNumber
 #   - jira_version
 #   - jira_baseUrl
@@ -22,7 +22,7 @@ pinfo = JSON.load(info)
 pinfo.each do |key, value|
   actual_value = value
   if value.is_a? Array
-     actual_value = value.join(',')
+    actual_value = value.join(',')
   end
   puts "jira_#{key.to_s.chomp()}=#{actual_value.to_s.chomp}"
 end


### PR DESCRIPTION
Use localhost instead of 127.0.0.1 so that we don't discriminate against IPv6-only configurations.