### PR TITLE
acceptance tests: use the default version of postgresql

### DIFF
--- a/spec/acceptance/default_parameters_spec.rb
+++ b/spec/acceptance/default_parameters_spec.rb
@@ -7,11 +7,6 @@ describe 'jira postgresql' do
         distribution => 'jre',
       }
 
-      class { 'postgresql::globals':
-        manage_package_repo => true,
-        version             => '9.4',
-      }
-
       class { 'postgresql::server': }
 
       postgresql::server::db { 'jira':


### PR DESCRIPTION
Version 9.4 doesn't exist in the postgresql.org repos anymore, which caused this test to fail. Simply using the default version that the puppetlabs-postgresql module wants works fine.