### PR TITLE
acceptance tests: update Jira version to current LTS release, 8.13.4

### DIFF
--- a/spec/acceptance/default_parameters_spec.rb
+++ b/spec/acceptance/default_parameters_spec.rb
@@ -15,7 +15,7 @@ describe 'jira postgresql' do
       }
 
       class { 'jira':
-        version      => '7.13.0',
+        version      => '8.13.4',
         javahome     => '/usr',
       }
 
@@ -62,7 +62,7 @@ describe 'jira postgresql' do
   end
 
   describe command('wget -q --tries=24 --retry-connrefused --read-timeout=10 -O- localhost:8080') do
-    its(:stdout) { is_expected.to match(%r{7\.13\.0}) }
+    its(:stdout) { is_expected.to include('8.13.4') }
   end
 
   describe 'shutdown' do

--- a/spec/acceptance/mysql_spec.rb
+++ b/spec/acceptance/mysql_spec.rb
@@ -36,7 +36,7 @@ describe 'jira mysql' do
       class { 'jira':
         installdir           => '/opt/atlassian-jira',
         homedir              => '/opt/jira-home',
-        version              => '8.9.0',
+        version              => '8.13.4',
         javahome             => '/usr',
         db                   => 'mysql',
         dbport               => '3306',
@@ -92,11 +92,11 @@ describe 'jira mysql' do
   end
 
   describe command('wget -q --tries=24 --retry-connrefused --no-check-certificate --read-timeout=10 -O- localhost:8081') do
-    its(:stdout) { is_expected.to match(%r{8\.9\.0}) }
+    its(:stdout) { is_expected.to include('8.13.4') }
   end
 
   describe command('wget -q --tries=24 --retry-connrefused --no-check-certificate --read-timeout=10 -O- https://localhost:8443') do
-    its(:stdout) { is_expected.to match(%r{8\.9\.0}) }
+    its(:stdout) { is_expected.to include('8.13.4') }
   end
 
   describe 'shutdown' do


### PR DESCRIPTION
Update Jira version to current LTS release, 8.13.4.

Needs #340 for tests to pass.