### PR TITLE
templates/facts.rb.erb: update URI.open syntax to fix deprecation warnings

### DIFF
--- a/templates/facts.rb.erb
+++ b/templates/facts.rb.erb
@@ -11,10 +11,10 @@
 # Purpose: Return facts for the running version of jira.
 #
 require 'json'
-require 'open-uri'
+require 'uri'
 begin
   url = 'http://<%= @uri %>:<%= @port %><%= @contextpath %>/rest/api/2/serverInfo'
-  info = open(url, &:read)
+  info = URI.open(url).read
 rescue
   exit 0
 end


### PR DESCRIPTION
templates/facts.rb.erb: update URI.open syntax to fix deprecation warnings

Fixes #330.