### PR TITLE
facts.pp: use less restrictive mode for the external fact script

### DIFF
--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -57,6 +57,6 @@ class jira::facts (
   file { "/etc/${dir}facter/facts.d/jira_facts.rb":
     ensure  => $ensure,
     content => template('jira/facts.rb.erb'),
-    mode    => '0500',
+    mode    => '0755',
   }
 }

--- a/spec/classes/jira_facts_spec.rb
+++ b/spec/classes/jira_facts_spec.rb
@@ -14,7 +14,7 @@ describe 'jira::facts' do
         pe_external_fact_file = '/etc/puppetlabs/facter/facts.d/jira_facts.rb'
         external_fact_file = '/etc/puppetlabs/facter/facts.d/jira_facts.rb'
 
-        it { is_expected.to contain_file(external_fact_file) }
+        it { is_expected.to contain_file(external_fact_file).with_mode('0755') }
         it { is_expected.to compile.with_all_deps }
 
         # Test puppet enterprise shebang generated correctly


### PR DESCRIPTION
There is nothing sensitive about the content of this script, so let's use the standard mode 0755 used for executables.