### PR TITLE
Fix unit tests after sysvinit patch broke them

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,7 @@
 class jira::params {
   Exec { path => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'] }
 
-  $service_file_location = '/usr/lib/systemd/system/jira.service'
+  $service_file_location = '/lib/systemd/system/jira.service'
   $service_file_template = 'jira/jira.service.erb'
   $service_file_mode     = '0644'
 


### PR DESCRIPTION
Fixes: 23242f9f7a68f6d0728bc2c3d7b1198570f69b34

Now I do notice that my patch ends up moving the .service file on Debian-based OSes from /lib/systemd to /usr/lib/systemd. It was marked as a backwards incompatible change but it may still surprise users. Thoughts?