### PR TITLE
Remove special code path for Puppet Enterprise

### DIFF
--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -26,35 +26,28 @@ class jira::facts (
   },
   # lint:endignore
 ) inherits jira::params {
-  # Puppet Enterprise supplies its own ruby version if your using it.
-  # A modern ruby version is required to run the executable fact
-  if $facts['puppetversion'] =~ /Puppet Enterprise/ {
-    $ruby_bin = '/opt/puppet/bin/ruby'
-    $dir = 'puppetlabs/'
-  } elsif $facts['aio_agent_version'] =~ String[1] {
+  if $facts['aio_agent_version'] =~ String[1] {
     $ruby_bin = '/opt/puppetlabs/puppet/bin/ruby'
-    $dir      = 'puppetlabs/'
+    $dir      = '/etc/puppetlabs/facter'
   } else {
     $ruby_bin = '/usr/bin/env ruby'
-    $dir = ''
-  }
+    $dir = '/etc/facter'
 
-  if !defined(File["/etc/${dir}facter"]) {
-    file { "/etc/${dir}facter":
-      ensure => directory,
-    }
-  }
-  if !defined(File["/etc/${dir}facter/facts.d"]) {
-    file { "/etc/${dir}facter/facts.d":
-      ensure => directory,
-    }
-  }
-
-  if $facts['os']['family'] == 'RedHat' and $facts['puppetversion'] !~ /Puppet Enterprise/ {
     ensure_packages ($json_packages, { ensure => present })
   }
 
-  file { "/etc/${dir}facter/facts.d/jira_facts.rb":
+  if !defined(File[$dir]) {
+    file { $dir:
+      ensure => directory,
+    }
+  }
+  if !defined(File["${dir}/facts.d"]) {
+    file { "${dir}/facts.d":
+      ensure => directory,
+    }
+  }
+
+  file { "${dir}/facts.d/jira_facts.rb":
     ensure  => $ensure,
     content => template('jira/facts.rb.erb'),
     mode    => '0755',

--- a/spec/classes/jira_facts_spec.rb
+++ b/spec/classes/jira_facts_spec.rb
@@ -8,37 +8,42 @@ describe 'jira::facts' do
         end
         let(:pre_condition) { "class{'::jira': javahome => '/opt/java'}" }
 
-        regexp_pe = %r{^#\!/opt/puppet/bin/ruby$}
-        regexp_oss = %r{^#\!/opt/puppetlabs/puppet/bin/ruby$}
-        regexp_url = %r{http://127.0.0.1\:8080/rest/api/2/serverInfo}
-        pe_external_fact_file = '/etc/puppetlabs/facter/facts.d/jira_facts.rb'
-        external_fact_file = '/etc/puppetlabs/facter/facts.d/jira_facts.rb'
-
-        it { is_expected.to contain_file(external_fact_file).with_mode('0755') }
         it { is_expected.to compile.with_all_deps }
 
-        # Test puppet enterprise shebang generated correctly
-        context 'with puppet enterprise' do
+        context 'with puppet AIO' do
           let(:facts) do
-            facts.merge(puppetversion: '3.4.3 (Puppet Enterprise 3.2.1)')
+            facts.merge(aio_agent_version: 'something')
           end
 
           it do
-            is_expected.to contain_file(pe_external_fact_file). \
-              with_content(regexp_pe).
-              with_content(regexp_url)
+            is_expected.to contain_file('/etc/puppetlabs/facter/facts.d/jira_facts.rb'). \
+              with_content(%r{#!/opt/puppetlabs/puppet/bin/ruby}).
+              with_content(%r{http://127\.0\.0\.1:8080/rest/api/2/serverInfo})
           end
+
+          it { is_expected.not_to contain_file('/etc/facter/facts.d/jira_facts.rb') }
+          it { is_expected.not_to contain_package('rubygem-json') }
+          it { is_expected.not_to contain_package('ruby-json') }
         end
-        # Test puppet oss shebang generated correctly
+
         context 'with puppet oss' do
           let(:facts) do
-            facts.merge(puppetversion: 'all other versions')
+            facts.merge(aio_agent_version: nil)
           end
 
+          it { is_expected.not_to contain_file('/etc/puppetlabs/facter/facts.d/jira_facts.rb') }
+
           it do
-            is_expected.to contain_file(external_fact_file). \
-              with_content(regexp_oss). \
-              with_content(regexp_url)
+            is_expected.to contain_file('/etc/facter/facts.d/jira_facts.rb'). \
+              with_content(%r{#!/opt/puppet/bin/ruby}).
+              with_content(%r{http://127\.0\.0\.1:8080/rest/api/2/serverInfo})
+          end
+
+          case facts[:osfamily]
+          when 'RedHat'
+            it { is_expected.to contain_package('rubygem-json') }
+          when 'Debian'
+            it { is_expected.to contain_package('ruby-json') }
           end
         end
 
@@ -48,7 +53,7 @@ describe 'jira::facts' do
           end
 
           it do
-            is_expected.to contain_file(external_fact_file). \
+            is_expected.to contain_file('/etc/puppetlabs/facter/facts.d/jira_facts.rb'). \
               with_content(%r{  url = 'http://127.0.0.1:8080/jira})
           end
         end


### PR DESCRIPTION
On Puppet Enterprise the aio_agent_version fact should also be set so it's redundant.

The json_packages code is made generic so it's executed on all non-AIO installs.