### PR TITLE
Updating check-java.sh and server.xml templates to upstream version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,14 @@ Puppet.
 
 * JIRA requires a Java Developers Kit (JDK) or Java Run-time Environment (JRE)
   platform to be installed on your server's operating system. Oracle JDK / JRE
-  (formerly Sun JDK / JRE) versions 7 and 8 are currently supported by Atlassian.
+  (formerly Sun JDK / JRE) versions 8 (and 11 since JIRA 8.2) are currently
+  supported by Atlassian. OpenJDK version 8 (and 11 since JIRA 8.2) are supported
+  as well - Atlassian recommends to use AdoptOpenJDK to get better support
 
 * JIRA requires a relational database to store its issue data. This module
-  currently supports PostgreSQL 8.4 to 9.x and MySQL 5.x and Oracle 11g and
-  Microsoft SQL Server 2008 & 2012. We suggest using
-  puppetlabs-postgresql/puppetlabs-mysql modules to configure/manage the
-  database. The module uses PostgreSQL as a default.
+  currently supports PostgreSQL and MySQL and Oracle and Microsoft SQL Server.
+  We suggest using puppetlabs-postgresql/puppetlabs-mysql modules to
+  configure/manage the database. The module uses PostgreSQL as a default.
 
 * Whilst not required, for production use we recommend using nginx/apache as a
   reverse proxy to JIRA. We suggest using the jfryman/nginx puppet module.
@@ -728,8 +729,10 @@ The puppetlabs repositories can be found at:
 * Oracle Linux 7
 * Ubuntu 18.04
 
+* Jira 8.x
+
 * PostgreSQL
-* MySQL 5.x
+* MySQL
 * Oracle 11G with Oracle 11.2.x drivers
 * Microsoft SQL Server 2005/2008/2012 with JTDS driver (included in non-WAR version)
 
@@ -784,4 +787,4 @@ export download_url="'http://my.local.server/'"
 
 ## Contributors
 
-The list of contributors can be found [here](https://github.com/brycejohnson/puppet-jira/graphs/contributors)
+The list of contributors can be found [here](https://github.com/voxpupuli/puppet-jira/graphs/contributors)

--- a/templates/check-java.sh.erb
+++ b/templates/check-java.sh.erb
@@ -1,26 +1,59 @@
-#!/bin/sh
+#!/bin/bash
 # This file is managed by Puppet
-
-# This file should be identical to 'check-java.sh' in the Jira 7.0.4 standalone
-# tarball.
-
-_EXPECTED_JAVA_VERSION="8"
+#
+# This file is nearly identical to 'check-java.sh' in the Jira 8.15.0 standalone tarball. Shebang was changed to bash
+# (does not need to stay /bin/sh, since it is called by catalina.sh, which itself has /bin/bash as shebang) to allow
+# bashisms. Also errors detected by shellcheck were fixed .
 
 #
 # check for correct java version by parsing out put of java -version
-# we expect first line to be in format 'java version "1.8.0_40"' and assert that minor version number will be 8 or higher
+# we expect first line to be in format 'java version "1.8.0_161"' or 'java version "10.0.1" 2018-04-17'
+# or 'openjdk version "11-ea" 2018-09-25' and assert that version number will be 8 or 11 (if enabled)
+# or sth like 'Picked up JDK_JAVA_OPTIONS:' (which we need to skip)
 #
 
-"$_RUNJAVA" -version 2>&1 | grep "java version" | (
-        IFS=. read ignore1 version ignore2
-        if [ ! ${version:-0} -ge "$_EXPECTED_JAVA_VERSION" ]
-        then
-           echo "*************************************************************************************************************************************"
-           echo "**********     Wrong JVM version! You are running with "$ignore1"."$version"."$ignore2" but JIRA requires at least 1.8 to run.      **********"
-           echo "*************************************************************************************************************************************"
-           exit 1
-        fi
-    )
-if [ $? -ne 0 ] ; then
-   exit 1
+java_raw_version=$($_RUNJAVA -version 2>&1 | grep -v "JDK_JAVA_OPTIONS" | grep "version" | awk '{ print substr($3, 2, length($3)-2); }')
+java_version=0
+
+if [[ $java_raw_version = *-ea* ]]
+then
+	# early access format e.g 11-ea
+    IFS='-' read -ra values <<< "$java_raw_version"
+    java_version=${values[0]}
+else
+	if [[ $java_raw_version = 1.* ]]
+	then
+		# old format e.g. 1.8.0_161
+	  IFS='.' read -ra values <<< "$java_raw_version"
+		java_version=${values[1]}
+	else
+		# new format e.g. 10.0.1
+		IFS='.' read -ra values <<< "$java_raw_version"
+		java_version=${values[0]}
+	fi
+fi
+
+if [ "$java_version" -ne 8 ] && [ "$java_version" -ne 11 ]
+then
+    echo "****************************************************************************"
+    echo "*******      Wrong JVM version! Jira requires 1.8 or 11 to run.      *******"
+    echo "****************************************************************************"
+    echo "***"
+    echo "*** Output of java -version command is:"
+    $_RUNJAVA -version 2>&1
+    echo "*** (End of output) ***"
+    echo "***"
+    if [ "$ignore_jvm_version" = "true" ]
+    then
+        echo "*** Environment variable 'ignore_jvm_version' is set to 'true'"
+        echo "*** Jira is going to bypass restriction and run using existing JVM version"
+        echo "***"
+        echo "****************************************************************************"
+    else
+        echo "*** If you want Jira to start using this JVM"
+        echo "*** set environment variable 'ignore_jvm_version' to 'true'"
+        echo "***"
+        echo "****************************************************************************"
+        exit 1
+    fi
 fi

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -1,16 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-   ====================================================================================
 
-   Atlassian JIRA Standalone Edition Tomcat Configuration.
-
-
-   See the following for more information
-
-   http://confluence.atlassian.com/display/JIRA/Configuring+JIRA+Standalone
-
-   ====================================================================================
- -->
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -28,21 +17,16 @@
   limitations under the License.
 -->
 <Server port="<%= @tomcat_shutdown_port %>" shutdown="SHUTDOWN">
-
-    <!--APR library loader. Documentation at /docs/apr.html -->
     <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+    <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener"/>
     <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener"/>
+    <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener"/>
+
 <%- if scope.function_versioncmp([@version, '6.4.14']) <= 0 && @product =~ /^jira/ -%>
     <Listener className="org.apache.catalina.core.JasperListener"/>
 <% else -%>
     <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
 <%- end -%>
-    <!-- Security listener. Documentation at /docs/config/listeners.html
-    <Listener className="org.apache.catalina.security.SecurityListener" />
-    -->
-    <!-- Prevent memory leaks due to use of particular java/javax APIs-->
-    <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
-    <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
 
     <Service name="Catalina">
         <Connector port="<%= @tomcat_port %>"
@@ -61,7 +45,11 @@
                    protocol="<%= @tomcat_protocol %>"
                    useBodyEncodingForURI="<%= @tomcat_use_body_encoding_for_uri %>"
                    acceptCount="<%= @tomcat_accept_count %>"
+<%   if ! @proxy['scheme'] -%>
+                   scheme="http"
+<%   end -%>
                    disableUploadTimeout="<%= @tomcat_disable_upload_timeout %>"
+                   bindOnInit="false"
 <% if @tomcat_native_ssl && @tomcat_redirect_https_port -%>
                    redirectPort="<%= @tomcat_redirect_https_port %>"
 <% else -%>
@@ -137,6 +125,7 @@
                               factory="org.objectweb.jotm.UserTransactionFactory" jotm.timeout="60"/>
                     <Manager pathname=""/>
                     <JarScanner scanManifest="false"/>
+                    <Valve className="org.apache.catalina.valves.StuckThreadDetectionValve" threshold="120" />
                 </Context>
 
             </Host>


### PR DESCRIPTION
#### Pull Request (PR) description
Updates check-java.sh and server.xml templates to upstream version. Especially the check-java update is required, when using a java version > 8 (or 1.8, depending which versioning scheme you look at.

#### This Pull Request (PR) fixes the following issues
Fixes #339 
Kind of fixes #300 

This replaces PR #317.
