### PR TITLE
Fix Ruby path expectation

### DIFF
--- a/spec/classes/jira_facts_spec.rb
+++ b/spec/classes/jira_facts_spec.rb
@@ -35,7 +35,7 @@ describe 'jira::facts' do
 
           it do
             is_expected.to contain_file('/etc/facter/facts.d/jira_facts.rb'). \
-              with_content(%r{#!/opt/puppet/bin/ruby}).
+              with_content(%r{#!/usr/bin/env ruby}).
               with_content(%r{http://127\.0\.0\.1:8080/rest/api/2/serverInfo})
           end
 


### PR DESCRIPTION
In 6364236b8a9296f527647fd5738254772f6c1e00 a wrong path was checked and somehow the tests didn't run so was merged. This corrects the expectation.

Fixes: 6364236b8a9296f527647fd5738254772f6c1e00