### PR TITLE
Add handling for X-Forwarded-For in access logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,14 @@ https://confluence.atlassian.com/kb/how-to-create-an-unproxied-application-link-
 and
 https://confluence.atlassian.com/kb/how-to-bypass-a-reverse-proxy-or-ssl-in-application-links-719095724.html
 
+##### `$tomcat_accesslog_enable_xforwarded_for`
+
+If a proxy operates before JIRA, the access logs will only contain the IP addresses of the proxy
+instead of the address of the user. With `X-Forwarded-For` the proxy can forward the users IP
+address to the JIRA application server so that it can be logged correctly.
+
+Defaults to `false`.
+
 #### Crowd single sign on parameters
 
 #### `enable_sso`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -143,6 +143,7 @@ class jira (
   $tomcat_keystore_pass                                             = 'changeit',
   Enum['JKS', 'JCEKS', 'PKCS12'] $tomcat_keystore_type              = 'JKS',
   $tomcat_accesslog_format                                          = '%a %{jira.request.id}r %{jira.request.username}r %t &quot;%m %U%q %H&quot; %s %b %D &quot;%{Referer}i&quot; &quot;%{User-Agent}i&quot; &quot;%{jira.request.assession.id}r&quot;',
+  Boolean $tomcat_accesslog_enable_xforwarded_for                   = false,
   # Tomcat Tunables
   $tomcat_max_threads                                               = '150',
   $tomcat_accept_count                                              = '100',

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -463,6 +463,22 @@ describe 'jira' do
             end
           end
 
+          context 'tomcat access log format with x-forward-for handling' do
+            let(:params) do
+              {
+                version: '8.12.1',
+                javahome: '/opt/java',
+                tomcat_accesslog_enable_xforwarded_for: true,
+              }
+            end
+
+            it do
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/conf/server.xml').
+                with_content(%r{org.apache.catalina.valves.RemoteIpValve}).
+                with_content(%r{requestAttributesEnabled="true"})
+            end
+          end
+
           context 'with script_check_java_managed enabled' do
             let(:params) do
               {

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -130,9 +130,18 @@
 
             </Host>
 
-            <Valve className="org.apache.catalina.valves.AccessLogValve" resolveHosts="false"
-                   pattern="<%= @tomcat_accesslog_format %>"/>
+          <Valve className="org.apache.catalina.valves.AccessLogValve" resolveHosts="false"
+<% if @tomcat_accesslog_enable_xforwarded_for %>
+                 requestAttributesEnabled="true"
+<% end -%>
+                 pattern="<%= @tomcat_accesslog_format %>"/>
 
+<% if @tomcat_accesslog_enable_xforwarded_for %>
+            <Valve
+              className="org.apache.catalina.valves.RemoteIpValve"
+              remoteIpHeader="x-forwarded-for"
+              remoteIpProxiesHeader="x-forwarded-by"/>
+<% end -%>
         </Engine>
     </Service>
 </Server>


### PR DESCRIPTION
#### Pull Request (PR) description
Adding handling for X-Forwarded-For in access logs

#### This Pull Request (PR) fixes the following issues
If a proxy operates before JIRA, the access logs will only contain the IPs of the proxy instead of the IP of the user. With X-Forwarded-For the proxy can forward the users IP to the JIRA application server so that it can be logged correctly
