### PR TITLE
Restore $jira::java_opts for compatibility and remove $jira::jvm_*_additional from the API, as setting JDK type to custom allows full control anyway.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,15 +91,11 @@ class jira (
   String $jvm_xmx                                                   = '1024m',
   String $jvm_permgen                                               = '256m',
   Optional[String] $jvm_optional                                    = undef,
-  Optional[String] $jvm_optional_additional                         = undef,
   Optional[String] $jvm_extra_args                                  = undef,
-  Optional[String] $jvm_extra_args_additional                       = undef,
   Optional[String] $jvm_gc_args                                     = undef,
-  Optional[String] $jvm_gc_args_additional                          = undef,
   Optional[String] $jvm_codecache_args                              = undef,
-  Optional[String] $jvm_codecache_args_additional                   = undef,
   Integer $jvm_nofiles_limit                                        = 16384,
-  String $java_opts                                                 = '',
+  Optional[String] $java_opts                                       = undef,
   String $catalina_opts                                             = '',
   # Misc Settings
   Stdlib::HTTPUrl $download_url                                     = 'https://product-downloads.atlassian.com/software/jira/downloads',
@@ -171,6 +167,13 @@ class jira (
 ) inherits jira::params {
   if $datacenter and !$shared_homedir {
     fail("\$shared_homedir must be set when \$datacenter is true")
+  }
+
+  if $java_opts {
+    deprecation('jira::java_opts', 'jira::java_opts is deprecated. Please use jira::jvm_extra_args')
+    $jvm_extra_args_real = "${java_opts} ${jvm_extra_args}"
+  } else {
+    $jvm_extra_args_real = $jvm_extra_args
   }
 
   if $tomcat_redirect_https_port {

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -733,10 +733,10 @@ describe 'jira' do
                 version: '8.12.1',
                 javahome: '/opt/java',
                 jvm_type: 'openjdk-11',
-                jvm_optional_additional: '-XX:-TEST_OPTIONAL',
-                jvm_gc_args_additional: '-XX:-TEST_GC_ARG',
-                jvm_codecache_args_additional: '-XX:-TEST_CODECACHE',
-                jvm_extra_args_additional: '-XX:-TEST_EXTRA'
+                jvm_optional: '-XX:-TEST_OPTIONAL',
+                jvm_gc_args: '-XX:-TEST_GC_ARG',
+                jvm_codecache_args: '-XX:-TEST_CODECACHE',
+                jvm_extra_args: '-XX:-TEST_EXTRA'
               }
             end
 

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -12,9 +12,9 @@ JIRA_HOME="<%= @homedir %>"
 #  Occasionally Atlassian Support may recommend that you set some specific JVM arguments.  You can use this variable below to do that.
 #
 <%- if @jvm_type == 'openjdk-11' -%>
-JVM_SUPPORT_RECOMMENDED_ARGS='-XX:-HeapDumpOnOutOfMemoryError <%= @jvm_optional_additional %>'
+JVM_SUPPORT_RECOMMENDED_ARGS='-XX:-HeapDumpOnOutOfMemoryError <%= @jvm_optional %>'
 <%- elsif @jvm_type == 'oracle-jdk-1.8' -%>
-JVM_SUPPORT_RECOMMENDED_ARGS='-XX:-HeapDumpOnOutOfMemoryError <%= @jvm_optional_additional %>'
+JVM_SUPPORT_RECOMMENDED_ARGS='-XX:-HeapDumpOnOutOfMemoryError <%= @jvm_optional %>'
 <%- elsif @jvm_type == 'custom' -%>
 JVM_SUPPORT_RECOMMENDED_ARGS='<%= @jvm_optional %>'
 <%- end -%>
@@ -26,9 +26,9 @@ JVM_SUPPORT_RECOMMENDED_ARGS='<%= @jvm_optional %>'
 #  For Java 11 and larger heaps we recommend: -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent
 #
 <%- if @jvm_type == 'openjdk-11' -%>
-JVM_GC_ARGS='-XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent <%= @jvm_gc_args_additional %>'
+JVM_GC_ARGS='-XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent <%= @jvm_gc_args %>'
 <%- elsif @jvm_type == 'oracle-jdk-1.8' -%>
-JVM_GC_ARGS='<%= @jvm_gc_args_additional %>'
+JVM_GC_ARGS='<%= @jvm_gc_args %>'
 <%- elsif @jvm_type == 'custom' -%>
 JVM_GC_ARGS='<%= @jvm_gc_args %>'
 <%- end -%>
@@ -44,9 +44,9 @@ JVM_PERMGEN_MEMORY='<%= @jvm_permgen %>'
 # The following setting configures the size of JVM code cache.  A high value of reserved size allows Jira to work with more installed apps.
 #
 <%- if @jvm_type == 'openjdk-11' -%>
-JVM_CODE_CACHE_ARGS='-XX:InitialCodeCacheSize=32m -XX:ReservedCodeCacheSize=512m <%= @jvm_codecache_args_additional %>'
+JVM_CODE_CACHE_ARGS='-XX:InitialCodeCacheSize=32m -XX:ReservedCodeCacheSize=512m <%= @jvm_codecache_args %>'
 <%- elsif @jvm_type == 'oracle-jdk-1.8' -%>
-JVM_CODE_CACHE_ARGS='-XX:InitialCodeCacheSize=32m -XX:ReservedCodeCacheSize=512m <%= @jvm_codecache_args_additional %>'
+JVM_CODE_CACHE_ARGS='-XX:InitialCodeCacheSize=32m -XX:ReservedCodeCacheSize=512m <%= @jvm_codecache_args %>'
 <%- elsif @jvm_type == 'custom' -%>
 JVM_CODE_CACHE_ARGS='<%= @jvm_codecache_args %>'
 <%- end -%>
@@ -82,12 +82,12 @@ DISABLE_NOTIFICATIONS='-Datlassian.mail.senddisabled=true -Datlassian.mail.fetch
 # occurs frequently, which could make it harder for support to diagnose a problem.
 #-----------------------------------------------------------------------------------
 <%- if @jvm_type == 'openjdk-11' -%>
-JVM_EXTRA_ARGS='<%= @jvm_extra_args_additional %>'
+JVM_EXTRA_ARGS='<%= @jvm_extra_args_real %>'
 JVM_EXTRA_ARGS+='-XX:+ExplicitGCInvokesConcurrent -XX:-OmitStackTraceInFastThrow -Djava.locale.providers=COMPAT'
 <%- elsif @jvm_type == 'oracle-jdk-1.8' -%>
-JVM_EXTRA_ARGS='-XX:+PrintGCDateStamps -XX:+ExplicitGCInvokesConcurrent -XX:-OmitStackTraceInFastThrow -Djava.locale.providers=COMPAT <%= @jvm_extra_args_additional %>'
+JVM_EXTRA_ARGS='-XX:+PrintGCDateStamps -XX:+ExplicitGCInvokesConcurrent -XX:-OmitStackTraceInFastThrow -Djava.locale.providers=COMPAT <%= @jvm_extra_args_real %>'
 <%- elsif @jvm_type == 'custom' -%>
-JVM_EXTRA_ARGS='<%= @jvm_extra_args %>'
+JVM_EXTRA_ARGS='<%= @jvm_extra_args_real %>'
 <%- end -%>
 
 CURRENT_NOFILES_LIMIT=$( ulimit -Hn )


### PR DESCRIPTION
The _additional API is not useful at all; if people want to fully override their configuration, they can set their JDK type to custom

Test fixes missing for now, but I've tested this against an actual Jira instance