### PR TITLE
Allow specifying JDBC connection parameters with jira::connection_settings

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,6 +62,7 @@ class jira (
   Optional[String] $dbdriver                                        = undef,
   Optional[String] $dbtype                                          = undef,
   Optional[String] $dburl                                           = undef,
+  Optional[String] $connection_settings                             = undef,
   $dbschema                                                         = undef,
   # MySQL Connector Settings
   $mysql_connector_manage                                           = true,

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -24,13 +24,40 @@ describe 'jira' do
             end
             it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/bin/user.sh') }
             it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml') }
+            # Also ensure that we actually omit elements by default
             it do
               is_expected.to contain_file('/home/jira/dbconfig.xml').
                 with_content(%r{jdbc:postgresql://localhost:5432/jira}).
-                with_content(%r{<schema-name>public</schema-name>})
+                with_content(%r{<schema-name>public</schema-name>}).
+                without_content(%r{<pool})
+
             end
             it { is_expected.not_to contain_file('/home/jira/cluster.properties') }
             it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/bin/check-java.sh') }
+          end
+
+          context 'database settings' do
+            let(:params) do
+              {
+                version: '6.3.4a',
+                javahome: '/opt/java',
+                connection_settings: 'TEST-SETTING;',
+                pool_max_size: 20,
+                pool_min_size: 10,
+                validation_query: 'SELECT version();',
+              }
+            end
+
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/bin/setenv.sh') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/bin/user.sh') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml') }
+            it do
+              is_expected.to contain_file('/home/jira/dbconfig.xml').
+                with_content(%r{<connection-settings>TEST-SETTING;</connection-settings>}).
+                with_content(%r{<pool-max-size>20</pool-max-size>}).
+                with_content(%r{<pool-min-size>10</pool-min-size>}).
+                with_content(%r{<validation-query>SELECT version\(\);</validation-query>})
+            end
           end
 
           context 'mysql params' do

--- a/templates/dbconfig.xml.epp
+++ b/templates/dbconfig.xml.epp
@@ -50,5 +50,8 @@
 <% if $jira::time_between_eviction_runs != undef { -%>
     <time-between-eviction-runs-millis><%= $jira::time_between_eviction_runs %></time-between-eviction-runs-millis>
 <% } -%>
+<% if $jira::connection_settings { -%>
+    <connection-settings><%= $jira::connection_settings %></connection-settings>
+<% } -%>
   </jdbc-datasource>
 </jira-database-config>


### PR DESCRIPTION
Needs the dbconfig refactoring PR first. Adds an API to control JDBC connection parameters.