### PR TITLE
Sync setenv.sh with upstream 8.13.5 (LTS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Defaults to `http://cdn.mysql.com/Downloads/Connector-J`
 
 ##### `$javahome`
 
-The JAVA_HOME directory, defaults to undef. This is a *required* parameter
+The `JAVA_HOME` directory, defaults to undef. This is a *required* parameter
 
 ##### `$jvm_xms`
 
@@ -369,18 +369,28 @@ defaults to '256m'
 Maximum memory allocation pool for a Java Virtual Machine.
 defaults to '1024m'
 
-##### `$jvm_permgen`
+##### `$jvm_type`
 
-Increase max permgen size for a Java Virtual Machine.
-defaults to '256m'
-
-##### `$jvm_optional`
-
-defaults to '-XX:-HeapDumpOnOutOfMemoryError'
+Choose your JVM type. Valid values are 'openjdk-11', 'oracle-jdk-1.8'
+This setting affects various defaults in setenv.sh if the options aren't defined
 
 ##### `$java_opts`
 
-defaults to ''
+defaults to ''. This sets `JVM_SUPPORT_RECOMMENDED_ARGS` in setenv.sh
+
+##### `$jvm_gc_args`
+
+This sets `JVM_GC_ARGS` in `setenv.sh`. Defaults to undef, meaning
+the module makes a choice based on `jvm_type`
+
+##### `$jvm_code_cache_args`
+
+This sets `JVM_CODE_CACHE_ARGS` in `setenv.sh`. Defaults to undef, meaning
+the module makes a choice based on `jvm_type`
+
+##### `$jvm_extra_args`
+This sets `JVM_EXTRA_ARGS` in `setenv.sh`. Defaults to undef, meaning
+the module makes a choice based on `jvm_type`
 
 ##### `$catalina_opts`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -23,6 +23,15 @@ class jira::config {
     group => $jira::group,
   }
 
+  # JVM args. These will be the defaults if not overridden
+  if $jira::jvm_type == 'openjdk-11' {
+    $jvm_gc_args = '-XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent'
+  } else {
+    $jvm_gc_args = '-XX:+ExplicitGCInvokesConcurrent'
+  }
+  $jvm_code_cache_args = '-XX:InitialCodeCacheSize=32m -XX:ReservedCodeCacheSize=512m'
+  $jvm_extra_args = '-XX:-OmitStackTraceInFastThrow -Djava.locale.providers=COMPAT'
+
   $dbschema_default = $jira::db ? {
     'postgresql' => 'public',
     default      => undef
@@ -30,13 +39,6 @@ class jira::config {
 
   # can't use pick_default: https://tickets.puppetlabs.com/browse/MODULES-11018
   $dbschema = if $jira::dbschema { $jira::dbschema } else { $dbschema_default }
-
-  if $jira::java_opts {
-    deprecation('jira::java_opts', 'jira::java_opts is deprecated. Please use jira::jvm_extra_args')
-    $jvm_extra_args_real = "${jira::java_opts} ${jira::jvm_extra_args}"
-  } else {
-    $jvm_extra_args_real = $jira::jvm_extra_args
-  }
 
   # Allow some backwards compatibility;
   if $jira::poolsize {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,11 +88,10 @@ class jira (
   Jira::Jvm_types $jvm_type                                         = 'openjdk-11',
   String $jvm_xms                                                   = '256m',
   String $jvm_xmx                                                   = '1024m',
-  String $jvm_permgen                                               = '256m',
-  Optional[String] $jvm_optional                                    = undef,
-  Optional[String] $jvm_extra_args                                  = undef,
+  Optional[String] $java_opts                                       = undef,
   Optional[String] $jvm_gc_args                                     = undef,
-  Optional[String] $jvm_codecache_args                              = undef,
+  Optional[String] $jvm_code_cache_args                             = undef,
+  Optional[String] $jvm_extra_args                                  = undef,
   Integer $jvm_nofiles_limit                                        = 16384,
   String $catalina_opts                                             = '',
   # Misc Settings
@@ -161,12 +160,16 @@ class jira (
   Integer $session_validationinterval                               = 5,
   String $session_lastvalidation                                    = 'session.lastvalidation',
   # Deprecated parameters
+  Optional[String] $jvm_permgen                                     = undef,
   Optional[Integer[0]] $poolsize                                    = undef,
-  Optional[String] $java_opts                                       = undef,
   Optional[Boolean] $enable_connection_pooling                      = undef,
 ) inherits jira::params {
   if $datacenter and !$shared_homedir {
     fail("\$shared_homedir must be set when \$datacenter is true")
+  }
+
+  if $jvm_permgen {
+    fail('jira::jvm_permgen', 'jira::jvm_permgen has been removed and no longer does anything. Configuring it hasn\'t been supported since JDK 8')
   }
 
   if $enable_connection_pooling != undef {

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -705,7 +705,7 @@ describe 'jira' do
             it do
               is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/bin/setenv.sh').
                 with_content(%r{#DISABLE_NOTIFICATIONS=}).
-                with_content(%r{JVM_SUPPORT_RECOMMENDED_ARGS='\S+HeapDumpOnOutOfMemoryError}).
+                with_content(%r{JVM_SUPPORT_RECOMMENDED_ARGS=''}).
                 with_content(%r{JVM_GC_ARGS='.+ \-XX:\+ExplicitGCInvokesConcurrent}).
                 with_content(%r{JVM_CODE_CACHE_ARGS='\S+InitialCodeCacheSize=32m \S+ReservedCodeCacheSize=512m}).
                 with_content(%r{JVM_REQUIRED_ARGS='.+InterningDocumentFactory})
@@ -726,10 +726,9 @@ describe 'jira' do
               {
                 version: '8.12.1',
                 javahome: '/opt/java',
-                jvm_type: 'custom',
-                jvm_optional: '-XX:-TEST_OPTIONAL',
+                java_opts: '-XX:-TEST_OPTIONAL',
                 jvm_gc_args: '-XX:-TEST_GC_ARG',
-                jvm_codecache_args: '-XX:-TEST_CODECACHE',
+                jvm_code_cache_args: '-XX:-TEST_CODECACHE',
                 jvm_extra_args: '-XX:-TEST_EXTRA'
               }
             end
@@ -750,33 +749,6 @@ describe 'jira' do
                 with_content(%r{jdbc:postgresql://localhost:5432/jira}).
                 with_content(%r{<schema-name>public</schema-name>})
             end
-            it { is_expected.not_to contain_file('/home/jira/cluster.properties') }
-            it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/bin/check-java.sh') }
-          end
-
-          context 'jira-8.12 - openjdk-11 with additional jvm params' do
-            let(:params) do
-              {
-                version: '8.12.1',
-                javahome: '/opt/java',
-                jvm_type: 'openjdk-11',
-                jvm_optional: '-XX:-TEST_OPTIONAL',
-                jvm_gc_args: '-XX:-TEST_GC_ARG',
-                jvm_codecache_args: '-XX:-TEST_CODECACHE',
-                jvm_extra_args: '-XX:-TEST_EXTRA'
-              }
-            end
-
-            it { is_expected.to compile.with_all_deps }
-            it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/bin/setenv.sh').
-                with_content(%r{JVM_SUPPORT_RECOMMENDED_ARGS='.+TEST_OPTIONAL'}).
-                with_content(%r{JVM_GC_ARGS='.+TEST_GC_ARG'}).
-                with_content(%r{JVM_CODE_CACHE_ARGS='.+TEST_CODECACHE'}).
-                with_content(%r{JVM_EXTRA_ARGS='.+TEST_EXTRA'})
-            end
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/bin/user.sh') }
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/conf/server.xml') }
             it { is_expected.not_to contain_file('/home/jira/cluster.properties') }
             it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/bin/check-java.sh') }
           end

--- a/spec/type_aliases/jvm_types_spec.rb
+++ b/spec/type_aliases/jvm_types_spec.rb
@@ -3,8 +3,7 @@ require 'spec_helper'
 describe 'Jira::Jvm_types' do
   describe 'valid attributes' do
     ['openjdk-11',
-     'oracle-jdk-1.8',
-     'custom'].each do |value|
+     'oracle-jdk-1.8'].each do |value|
       describe value.inspect do
         it { is_expected.to allow_value(value) }
       end

--- a/templates/setenv.sh.epp
+++ b/templates/setenv.sh.epp
@@ -1,3 +1,5 @@
+<%# MAINTAINERS: try to keep diff with the original file to a minimum #-%>
+<%# Don't include shell style fixes unless they fix real bugs         #-%>
 #
 # If the limit of files that Jira can open is too low, it will be set to this value.
 #

--- a/templates/setenv.sh.epp
+++ b/templates/setenv.sh.epp
@@ -11,13 +11,8 @@ JIRA_HOME="<%= $jira::homedir %>"
 #
 #  Occasionally Atlassian Support may recommend that you set some specific JVM arguments.  You can use this variable below to do that.
 #
-<%- if $jira::jvm_type == 'openjdk-11' { -%>
-JVM_SUPPORT_RECOMMENDED_ARGS='-XX:-HeapDumpOnOutOfMemoryError <%= $jira::jvm_optional %>'
-<%- } elsif $jira::jvm_type == 'oracle-jdk-1.8' { -%>
-JVM_SUPPORT_RECOMMENDED_ARGS='-XX:-HeapDumpOnOutOfMemoryError <%= $jira::jvm_optional %>'
-<%- } elsif $jira::jvm_type == 'custom' { -%>
-JVM_SUPPORT_RECOMMENDED_ARGS='<%= $jira::jvm_optional %>'
-<%- } -%>
+# Puppet: $jira::jvm_type is <%= $jira::jvm_type %>
+JVM_SUPPORT_RECOMMENDED_ARGS='<%= $jira::java_opts %>'
 
 #
 #  You can use variable below to modify garbage collector settings.
@@ -25,31 +20,18 @@ JVM_SUPPORT_RECOMMENDED_ARGS='<%= $jira::jvm_optional %>'
 #  For Java 11 and relatively small heaps we recommend: -XX:+UseParallelGC
 #  For Java 11 and larger heaps we recommend: -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent
 #
-<%- if $jira::jvm_type == 'openjdk-11' { -%>
-JVM_GC_ARGS='-XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent <%= $jira::jvm_gc_args %>'
-<%- } elsif $jira::jvm_type == 'oracle-jdk-1.8' { -%>
-JVM_GC_ARGS='<%= $jira::jvm_gc_args %>'
-<%- } elsif $jira::jvm_type == 'custom' { -%>
-JVM_GC_ARGS='<%= $jira::jvm_gc_args %>'
-<%- } -%>
+JVM_GC_ARGS='<%= pick_default($jira::jvm_gc_args, $jira::config::jvm_gc_args) %>'
 
 #
 # The following 2 settings control the minimum and maximum given to the JIRA Java virtual machine.  In larger JIRA instances, the maximum amount will need to be increased.
 #
 JVM_MINIMUM_MEMORY='<%= $jira::jvm_xms %>'
 JVM_MAXIMUM_MEMORY='<%= $jira::jvm_xmx %>'
-JVM_PERMGEN_MEMORY='<%= $jira::jvm_permgen %>'
 
 #
 # The following setting configures the size of JVM code cache.  A high value of reserved size allows Jira to work with more installed apps.
 #
-<%- if $jira::jvm_type == 'openjdk-11' { -%>
-JVM_CODE_CACHE_ARGS='-XX:InitialCodeCacheSize=32m -XX:ReservedCodeCacheSize=512m <%= $jira::jvm_codecache_args %>'
-<%- } elsif $jira::jvm_type == 'oracle-jdk-1.8' { -%>
-JVM_CODE_CACHE_ARGS='-XX:InitialCodeCacheSize=32m -XX:ReservedCodeCacheSize=512m <%= $jira::jvm_codecache_args %>'
-<%- } elsif $jira::jvm_type == 'custom' { -%>
-JVM_CODE_CACHE_ARGS='<%= $jira::jvm_codecache_args %>'
-<%- } -%>
+JVM_CODE_CACHE_ARGS='<%= pick_default($jira::jvm_code_cache_args, $jira::config::jvm_code_cache_args) %>'
 
 #
 # The following are the required arguments for Jira.
@@ -65,9 +47,9 @@ JVM_REQUIRED_ARGS='-Djava.awt.headless=true -Datlassian.standalone=JIRA -Dorg.ap
 # Uncomment this setting if you want to import data without notifications
 #
 <%- if $jira::disable_notifications { -%>
-DISABLE_NOTIFICATIONS='-Datlassian.mail.senddisabled=true -Datlassian.mail.fetchdisabled=true -Datlassian.mail.popdisabled=true'
+DISABLE_NOTIFICATIONS=" -Datlassian.mail.senddisabled=true -Datlassian.mail.fetchdisabled=true -Datlassian.mail.popdisabled=true"
 <% } else { %>
-#DISABLE_NOTIFICATIONS='-Datlassian.mail.senddisabled=true -Datlassian.mail.fetchdisabled=true -Datlassian.mail.popdisabled=true'
+#DISABLE_NOTIFICATIONS=" -Datlassian.mail.senddisabled=true -Datlassian.mail.fetchdisabled=true -Datlassian.mail.popdisabled=true"
 <% } -%>
 
 
@@ -81,49 +63,29 @@ DISABLE_NOTIFICATIONS='-Datlassian.mail.senddisabled=true -Datlassian.mail.fetch
 # Prevents the JVM from suppressing stack traces if a given type of exception
 # occurs frequently, which could make it harder for support to diagnose a problem.
 #-----------------------------------------------------------------------------------
-<%- if $jira::jvm_type == 'openjdk-11' { -%>
-JVM_EXTRA_ARGS='<%= $jira::config::jvm_extra_args_real %>'
-JVM_EXTRA_ARGS+='-XX:+ExplicitGCInvokesConcurrent -XX:-OmitStackTraceInFastThrow -Djava.locale.providers=COMPAT'
-<%- } elsif $jira::jvm_type == 'oracle-jdk-1.8' { -%>
-JVM_EXTRA_ARGS='-XX:+PrintGCDateStamps -XX:+ExplicitGCInvokesConcurrent -XX:-OmitStackTraceInFastThrow -Djava.locale.providers=COMPAT <%= $jira::config::jvm_extra_args_real %>'
-<%- } elsif $jira::jvm_type == 'custom' { -%>
-JVM_EXTRA_ARGS='<%= $jira::config::jvm_extra_args_real %>'
-<%- } -%>
+JVM_EXTRA_ARGS='<%= pick_default($jira::jvm_extra_args, $jira::config::jvm_extra_args) %>'
 
 CURRENT_NOFILES_LIMIT=$( ulimit -Hn )
-ulimit -Sn "${CURRENT_NOFILES_LIMIT}"
+ulimit -Sn $CURRENT_NOFILES_LIMIT
 ulimit -n $(( CURRENT_NOFILES_LIMIT > MIN_NOFILES_LIMIT  ? CURRENT_NOFILES_LIMIT : MIN_NOFILES_LIMIT ))
 
-PRGDIR=$(dirname "$0")
+PRGDIR=`dirname "$0"`
 cat "${PRGDIR}"/jirabanner.txt
 
 JIRA_HOME_MINUSD=""
-if [ -n "${JIRA_HOME}" ]; then
-    echo "${JIRA_HOME}" | grep -q " "
+if [ "$JIRA_HOME" != "" ]; then
+    echo $JIRA_HOME | grep -q " "
     if [ $? -eq 0 ]; then
-        echo ""
-        echo "--------------------------------------------------------------------------------------------------------------------"
-        echo "   WARNING : You cannot have a JIRA_HOME environment variable set with spaces in it.  This variable is being ignored"
-        echo "--------------------------------------------------------------------------------------------------------------------"
+	    echo ""
+	    echo "--------------------------------------------------------------------------------------------------------------------"
+		echo "   WARNING : You cannot have a JIRA_HOME environment variable set with spaces in it.  This variable is being ignored"
+	    echo "--------------------------------------------------------------------------------------------------------------------"
     else
-        JIRA_HOME_MINUSD=-Djira.home="${JIRA_HOME}"
+		JIRA_HOME_MINUSD=-Djira.home=$JIRA_HOME
     fi
 fi
 
 JAVA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} ${JVM_CODE_CACHE_ARGS} ${JAVA_OPTS} ${JVM_REQUIRED_ARGS} ${DISABLE_NOTIFICATIONS} ${JVM_SUPPORT_RECOMMENDED_ARGS} ${JVM_EXTRA_ARGS} ${JIRA_HOME_MINUSD} ${START_JIRA_JAVA_OPTS}"
-
-# Perm Gen size needs to be increased if encountering OutOfMemoryError: PermGen problems. Specifying PermGen size is not valid on IBM JDKs
-JIRA_MAX_PERM_SIZE=${JVM_PERMGEN_MEMORY}
-if [ -f "${PRGDIR}/permgen.sh" ]; then
-    echo "Detecting JVM PermGen support..."
-    . "${PRGDIR}/permgen.sh"
-    if [ "${JAVA_PERMGEN_SUPPORTED}" = "true" ]; then
-        echo "PermGen switch is supported. Setting to ${JIRA_MAX_PERM_SIZE}"
-        JAVA_OPTS="-XX:MaxPermSize=${JIRA_MAX_PERM_SIZE} ${JAVA_OPTS}"
-    else
-        echo "PermGen switch is NOT supported and will NOT be set automatically."
-    fi
-fi
 
 export JAVA_OPTS
 
@@ -131,40 +93,40 @@ export JAVA_OPTS
 # !INSTALLER SET JAVA_HOME
 
 echo ""
-echo "If you encounter issues starting or stopping Jira, please see the Troubleshooting guide at https://docs.atlassian.com/jira/jadm-docs-0812/Troubleshooting+installation"
+echo "If you encounter issues starting or stopping Jira, please see the Troubleshooting guide at https://docs.atlassian.com/jira/jadm-docs-0813/Troubleshooting+installation"
 echo ""
-if [ -n "${JIRA_HOME_MINUSD}" ]; then
-    echo "Using JIRA_HOME:       ${JIRA_HOME}"
+if [ "$JIRA_HOME_MINUSD" != "" ]; then
+    echo "Using JIRA_HOME:       $JIRA_HOME"
 fi
 
 # set the location of the pid file
-if [ -z "${CATALINA_PID}" ] ; then
-    if [ -n "${CATALINA_HOME}" ] ; then
-        CATALINA_PID="${CATALINA_HOME}/work/catalina.pid"
-    elif [ -n "${CATALINA_HOME}" ] ; then
-        CATALINA_PID="${CATALINA_HOME}/work/catalina.pid"
+if [ -z "$CATALINA_PID" ] ; then
+    if [ -n "$CATALINA_BASE" ] ; then
+        CATALINA_PID="$CATALINA_BASE"/work/catalina.pid
+    elif [ -n "$CATALINA_HOME" ] ; then
+        CATALINA_PID="$CATALINA_HOME"/work/catalina.pid
     fi
 fi
 export CATALINA_PID
 
-if [ -z "${CATALINA_HOME}" ]; then
-  if [ -z "${CATALINA_HOME}" ]; then
-    LOGBASE=${PRGDIR}
+if [ -z "$CATALINA_BASE" ]; then
+  if [ -z "$CATALINA_HOME" ]; then
+    LOGBASE=$PRGDIR
     LOGTAIL=..
   else
-    LOGBASE=${CATALINA_HOME}
+    LOGBASE=$CATALINA_HOME
     LOGTAIL=.
   fi
 else
-  LOGBASE=${CATALINA_BASE}
+  LOGBASE=$CATALINA_BASE
   LOGTAIL=.
 fi
 
-PUSHED_DIR=$(pwd)
-cd ${LOGBASE}
-cd ${LOGTAIL}
-LOGBASEABS=$(pwd)
-cd ${PUSHED_DIR}
+PUSHED_DIR=`pwd`
+cd $LOGBASE
+cd $LOGTAIL
+LOGBASEABS=`pwd`
+cd $PUSHED_DIR
 
 echo ""
-echo "Server startup logs are located in ${LOGBASEABS}/logs/catalina.out"
+echo "Server startup logs are located in $LOGBASEABS/logs/catalina.out"

--- a/types/jvm_types.pp
+++ b/types/jvm_types.pp
@@ -1,2 +1,2 @@
 # @summary Java Virtual Machine (JVM) types
-type Jira::Jvm_types = Enum['openjdk-11', 'oracle-jdk-1.8', 'custom']
+type Jira::Jvm_types = Enum['openjdk-11', 'oracle-jdk-1.8']


### PR DESCRIPTION
This undeprecates $java_opts for backwards compatibility
and repurposes the other parameters to do what a custom $jvm_type
did previously.

It removes "-XX:HeapDumpOnOutOfMemoryError" because that's
not a default setting in the upstream setenv.sh

It also makes setting $jvm_permgen a no-op, since JIRA doesn't support
JDK older than 8 anymore and the option does nothing
