### PR TITLE
Drop support for JIRA <8.0.0

### DIFF
--- a/jira.yaml
+++ b/jira.yaml
@@ -18,9 +18,7 @@
 # 2.) Modify the database settings below according to your setup
 #
 # Atlassian jira Git Enterprise Source Control Server
-jira::jira_name: jira
-jira::version: 5.1.7
-jira::format: tar.gz
+jira::version: 8.13.5
 
 # Directory where the webapp will run from
 jira::installdir: /opt/jira
@@ -40,14 +38,6 @@ jira::db: postgresql
 #jira::db: oracle
 #jira::db: sqlserver
 
-jira::dbtype: postgres72
-#jira::dbtype: mysql
-#jira::dbtype: mssql
-
-jira::dbdriver: org.postgresql.Driver
-#jira::dbdriver: com.mysql.jdbc.Driver
-#jira::dbdriver: com.microsoft.sqlserver.jdbc.SQLServerDriver
-
 # Change these values to your jira database credentials
 jira::dbuser: jiraadm
 jira::dbpassword: jiraadm
@@ -62,8 +52,6 @@ jira::dbport: 5432
 # Schema
 # Default for postgres
 jira::dbschema: 'public'
-# Default for mssql
-#jira::dbschema: 'dbo'
 
 # The connection pool parameters
 jira::pool_min_size: 20
@@ -83,11 +71,10 @@ jira::pool_test_on_borrow: true
 jira::dbserver: localhost
 
 # Tomcat configuration
-# TODO because I'm never a fan of the stock tomcat settings
-jira::javahome: /opt/java/jdk1.6.0_33
+jira::javahome: /opt/java/openjdk-11-jre
 jira::jvm_xmx: 1024m
-jira::jvm_optional: -XX:-HeapDumpOnOutOfMemoryError
-#jira::jvm_optional: -XX:NewSize=256m -XX:MaxNewSize=256m -XX:SurvivorRatio=16
+jira::java_opts: -XX:-HeapDumpOnOutOfMemoryError
+#jira::java_opts: -XX:NewSize=256m -XX:MaxNewSize=256m -XX:SurvivorRatio=16
 # the New and SR figures are purely optional
 # for heap dumps add -XX:-HeapDumpOnOutOfMemoryError
 # by default jira has 256m permgen which is a good setting to go with

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -101,15 +101,7 @@ class jira::config {
     }
   }
 
-  if $jira::tomcat_protocol_ssl {
-    $tomcat_protocol_ssl_real = $jira::tomcat_protocol_ssl
-  } else {
-    if versioncmp($jira::version, '7.3.0') >= 0 {
-      $tomcat_protocol_ssl_real = 'org.apache.coyote.http11.Http11NioProtocol'
-    } else {
-      $tomcat_protocol_ssl_real = 'org.apache.coyote.http11.Http11Protocol'
-    }
-  }
+  $tomcat_protocol_ssl_real = pick($jira::tomcat_protocol_ssl, 'org.apache.coyote.http11.Http11NioProtocol')
 
   $jira_properties = {
     'jira.websudo.is.disabled' => !$jira::enable_secure_admin_sessions,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,9 +33,8 @@
 class jira (
 
   # Jira Settings
-  String $version                                                   = '8.13.4',
+  String $version                                                   = '8.13.5',
   String $product                                                   = 'jira',
-  String $format                                                    = 'tar.gz',
   Stdlib::Absolutepath $installdir                                  = '/opt/jira',
   Stdlib::Absolutepath $homedir                                     = '/home/jira',
   Boolean $manage_user                                              = true,
@@ -165,6 +164,10 @@ class jira (
   Optional[String] $java_opts                                       = undef,
   Optional[Boolean] $enable_connection_pooling                      = undef,
 ) inherits jira::params {
+  if versioncmp($jira::version, '8.0.0') < 0 {
+    fail('JIRA versions older than 8.0.0 are no longer supported. Please use an older version of this module to upgrade first.')
+  }
+
   if $datacenter and !$shared_homedir {
     fail("\$shared_homedir must be set when \$datacenter is true")
   }
@@ -179,12 +182,15 @@ class jira (
     }
   }
 
-  # The default Jira product starting with version 7 is 'jira-software'
-  if ((versioncmp($version, '7.0.0') >= 0) and ($product == 'jira')) {
+  # The default Jira product starting with version 7 is 'jira-software',
+  # but some old configuration may explicitly specify 'jira'
+  if $product == 'jira' {
     $product_name = 'jira-software'
   } else {
     $product_name = $product
   }
+
+  $webappdir = "${installdir}/atlassian-${product_name}-${version}-standalone"
 
   if defined('$::jira_version') {
     # If the running version of JIRA is less than the expected version of JIRA
@@ -193,13 +199,6 @@ class jira (
       notify { 'Attempting to upgrade JIRA': }
       exec { $stop_jira: before => Class['jira::install'] }
     }
-  }
-
-  $extractdir = "${installdir}/atlassian-${product_name}-${version}-standalone"
-  if $format == zip {
-    $webappdir = "${extractdir}/atlassian-${product_name}-${version}-standalone"
-  } else {
-    $webappdir = $extractdir
   }
 
   if ! empty($ajp) {
@@ -217,13 +216,6 @@ class jira (
 
   if $javahome == undef {
     fail('You need to specify a value for javahome')
-  }
-
-  # Archive module checksum_verify = true; this verifies checksum if provided, doesn't if not.
-  if $checksum == undef {
-    $checksum_verify = false
-  } else {
-    $checksum_verify = true
   }
 
   contain jira::install

--- a/spec/acceptance/default_parameters_spec.rb
+++ b/spec/acceptance/default_parameters_spec.rb
@@ -57,7 +57,7 @@ describe 'jira postgresql' do
   end
 
   describe command('wget -q --tries=24 --retry-connrefused --read-timeout=10 -O- localhost:8080') do
-    its(:stdout) { is_expected.to include('8.13.4') }
+    its(:stdout) { is_expected.to include('8.13.5') }
   end
 
   describe 'shutdown' do

--- a/spec/acceptance/mysql_spec.rb
+++ b/spec/acceptance/mysql_spec.rb
@@ -86,11 +86,11 @@ describe 'jira mysql' do
   end
 
   describe command('wget -q --tries=24 --retry-connrefused --no-check-certificate --read-timeout=10 -O- localhost:8081') do
-    its(:stdout) { is_expected.to include('8.13.4') }
+    its(:stdout) { is_expected.to include('8.13.5') }
   end
 
   describe command('wget -q --tries=24 --retry-connrefused --no-check-certificate --read-timeout=10 -O- https://localhost:8443') do
-    its(:stdout) { is_expected.to include('8.13.4') }
+    its(:stdout) { is_expected.to include('8.13.5') }
   end
 
   describe 'shutdown' do

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -12,18 +12,17 @@ describe 'jira' do
           context 'default params' do
             let(:params) do
               {
-                version: '6.3.4a',
                 javahome: '/opt/java'
               }
             end
 
             it { is_expected.to compile.with_all_deps }
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/bin/setenv.sh').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/bin/setenv.sh').
                 with_content(%r{#DISABLE_NOTIFICATIONS=})
             end
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/bin/user.sh') }
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/bin/user.sh') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml') }
             # Also ensure that we actually omit elements by default
             it do
               is_expected.to contain_file('/home/jira/dbconfig.xml').
@@ -33,13 +32,13 @@ describe 'jira' do
 
             end
             it { is_expected.not_to contain_file('/home/jira/cluster.properties') }
-            it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/bin/check-java.sh') }
+            it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/bin/check-java.sh') }
           end
 
           context 'database settings' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 connection_settings: 'TEST-SETTING;',
                 pool_max_size: 20,
@@ -48,9 +47,9 @@ describe 'jira' do
               }
             end
 
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/bin/setenv.sh') }
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/bin/user.sh') }
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/bin/setenv.sh') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/bin/user.sh') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml') }
             it do
               is_expected.to contain_file('/home/jira/dbconfig.xml').
                 with_content(%r{<connection-settings>TEST-SETTING;</connection-settings>}).
@@ -63,15 +62,15 @@ describe 'jira' do
           context 'mysql params' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 db: 'mysql'
               }
             end
 
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/bin/setenv.sh') }
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/bin/user.sh') }
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/bin/setenv.sh') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/bin/user.sh') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml') }
             it do
               is_expected.to contain_file('/home/jira/dbconfig.xml').
                 with_content(%r{jdbc:mysql://localhost:3306/jira})
@@ -81,7 +80,7 @@ describe 'jira' do
           context 'sqlserver params' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 db: 'sqlserver',
                 dbport: '1433',
@@ -89,9 +88,9 @@ describe 'jira' do
               }
             end
 
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/bin/setenv.sh') }
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/bin/user.sh') }
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/bin/setenv.sh') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/bin/user.sh') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml') }
             it do
               is_expected.to contain_file('/home/jira/dbconfig.xml').
                 with_content(%r{<schema-name>public</schema-name>})
@@ -101,7 +100,7 @@ describe 'jira' do
           context 'custom dburl' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 dburl: 'my custom dburl'
               }
@@ -116,59 +115,29 @@ describe 'jira' do
           context 'customise tomcat connector' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 tomcat_port: 9229
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
-                with_content(%r{<Connector port=\"9229\"\s+maxThreads=}m)
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
+                with_content(%r{<Connector port=\"9229\"\s+relaxedPathChars=}m)
             end
           end
 
           context 'server.xml listeners' do
-            context 'version less than 7' do
+            context 'version greater than 8' do
               let(:params) do
                 {
-                  version: '6.3.4a',
+                  version: '8.1.0',
                   javahome: '/opt/java'
                 }
               end
 
               it do
-                is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
-                  with_content(%r{<Listener className=\"org.apache.catalina.core.JasperListener\"})
-              end
-            end
-          end
-
-          context 'server.xml 7 listeners' do
-            let(:params) do
-              {
-                version: '7.0.4',
-                javahome: '/opt/java'
-              }
-            end
-
-            it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-software-7.0.4-standalone/conf/server.xml').
-                with_content(%r{<Listener className=\"org.apache.catalina.startup.VersionLoggerListener\"})
-            end
-          end
-
-          context 'server.xml listeners' do
-            context 'version greater than 7' do
-              let(:params) do
-                {
-                  version: '7.0.4',
-                  javahome: '/opt/java'
-                }
-              end
-
-              it do
-                is_expected.to contain_file('/opt/jira/atlassian-jira-software-7.0.4-standalone/conf/server.xml').
+                is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.1.0-standalone/conf/server.xml').
                   with_content(%r{<Listener className=\"org.apache.catalina.core.JreMemoryLeakPreventionListener\"})
               end
             end
@@ -177,7 +146,7 @@ describe 'jira' do
           context 'customise tomcat connector with a binding address' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 tomcat_port: 9229,
                 tomcat_address: '127.0.0.1'
@@ -185,22 +154,22 @@ describe 'jira' do
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
-                with_content(%r{<Connector port=\"9229\"\s+address=\"127\.0\.0\.1\"\s+maxThreads=}m)
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
+                with_content(%r{<Connector port=\"9229\"\s+address=\"127\.0\.0\.1\"\s+relaxedPathChars=}m)
             end
           end
 
           context 'tomcat context path' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 contextpath: '/jira'
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                 with_content(%r{path="/jira"})
             end
           end
@@ -208,14 +177,14 @@ describe 'jira' do
           context 'tomcat port' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 tomcat_port: 8888
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                 with_content(%r{port="8888"})
             end
           end
@@ -223,14 +192,14 @@ describe 'jira' do
           context 'tomcat acceptCount' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 tomcat_accept_count: 200
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                 with_content(%r{acceptCount="200"})
             end
           end
@@ -238,14 +207,14 @@ describe 'jira' do
           context 'tomcat MaxHttpHeaderSize' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 tomcat_max_http_header_size: 4096
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                 with_content(%r{maxHttpHeaderSize="4096"})
             end
           end
@@ -253,14 +222,14 @@ describe 'jira' do
           context 'tomcat MinSpareThreads' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 tomcat_min_spare_threads: 50
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                 with_content(%r{minSpareThreads="50"})
             end
           end
@@ -268,14 +237,14 @@ describe 'jira' do
           context 'tomcat ConnectionTimeout' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 tomcat_connection_timeout: 25000
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                 with_content(%r{connectionTimeout="25000"})
             end
           end
@@ -283,14 +252,14 @@ describe 'jira' do
           context 'tomcat EnableLookups' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 tomcat_enable_lookups: true
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                 with_content(%r{enableLookups="true"})
             end
           end
@@ -298,14 +267,14 @@ describe 'jira' do
           context 'tomcat Protocol' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 tomcat_protocol: 'HTTP/1.1'
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                 with_content(%r{protocol="HTTP/1.1"})
             end
           end
@@ -313,14 +282,14 @@ describe 'jira' do
           context 'tomcat UseBodyEncodingForURI' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 tomcat_use_body_encoding_for_uri: false
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                 with_content(%r{useBodyEncodingForURI="false"})
             end
           end
@@ -328,14 +297,14 @@ describe 'jira' do
           context 'tomcat DisableUploadTimeout' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 tomcat_disable_upload_timeout: false
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                 with_content(%r{disableUploadTimeout="false"})
             end
           end
@@ -343,14 +312,14 @@ describe 'jira' do
           context 'tomcat EnableLookups' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 tomcat_enable_lookups: true
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                 with_content(%r{enableLookups="true"})
             end
           end
@@ -358,14 +327,14 @@ describe 'jira' do
           context 'tomcat maxThreads' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 tomcat_max_threads: 300
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                 with_content(%r{maxThreads="300"})
             end
           end
@@ -373,7 +342,7 @@ describe 'jira' do
           context 'tomcat proxy path' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 proxy: {
                   'scheme'    => 'https',
@@ -384,7 +353,7 @@ describe 'jira' do
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                 with_content(%r{proxyName = 'www\.example\.com'}).
                 with_content(%r{scheme = 'https'}).
                 with_content(%r{proxyPort = '9999'})
@@ -395,7 +364,7 @@ describe 'jira' do
             context 'with valid config including protocol AJP/1.3' do
               let(:params) do
                 {
-                  version: '6.3.4a',
+                  version: '8.13.5',
                   javahome: '/opt/java',
                   ajp: {
                     'port'     => '8009',
@@ -405,14 +374,14 @@ describe 'jira' do
               end
 
               it do
-                is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+                is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                   with_content(%r{<Connector enableLookups="false" URIEncoding="UTF-8"\s+port = "8009"\s+protocol = "AJP/1.3"\s+/>})
               end
             end
             context 'with valid config including protocol org.apache.coyote.ajp.AjpNioProtocol' do
               let(:params) do
                 {
-                  version: '6.3.4a',
+                  version: '8.13.5',
                   javahome: '/opt/java',
                   ajp: {
                     'port'     => '8009',
@@ -422,7 +391,7 @@ describe 'jira' do
               end
 
               it do
-                is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+                is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                   with_content(%r{<Connector enableLookups="false" URIEncoding="UTF-8"\s+port = "8009"\s+protocol = "org.apache.coyote.ajp.AjpNioProtocol"\s+/>})
               end
             end
@@ -431,7 +400,7 @@ describe 'jira' do
           context 'tomcat additional connectors' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 tomcat_additional_connectors: {
                   8081 => {
@@ -456,7 +425,7 @@ describe 'jira' do
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                 with_content(%r{<Connector port="8081"}).
                 with_content(%r{connectionTimeout="20000"}).
                 with_content(%r{protocol="HTTP/1\.1"}).
@@ -478,14 +447,14 @@ describe 'jira' do
           context 'tomcat access log format' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 tomcat_accesslog_format: '%a %{jira.request.id}r %{jira.request.username}r %t %I'
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                 with_content(%r{pattern="%a %{jira.request.id}r %{jira.request.username}r %t %I"/>})
             end
           end
@@ -493,14 +462,14 @@ describe 'jira' do
           context 'tomcat access log format with x-forward-for handling' do
             let(:params) do
               {
-                version: '8.12.1',
+                version: '8.16.0',
                 javahome: '/opt/java',
                 tomcat_accesslog_enable_xforwarded_for: true,
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/conf/server.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.16.0-standalone/conf/server.xml').
                 with_content(%r{org.apache.catalina.valves.RemoteIpValve}).
                 with_content(%r{requestAttributesEnabled="true"})
             end
@@ -510,13 +479,13 @@ describe 'jira' do
             let(:params) do
               {
                 script_check_java_manage: true,
-                version: '7.0.4',
+                version: '8.1.0',
                 javahome: '/opt/java'
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-software-7.0.4-standalone/bin/check-java.sh').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.1.0-standalone/bin/check-java.sh').
                 with_content(%r{Wrong JVM version})
             end
           end
@@ -524,14 +493,14 @@ describe 'jira' do
           context 'context resources' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 resources: { 'testdb' => { 'auth' => 'Container' } }
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/context.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/context.xml').
                 with_content(%r{<Resource name = "testdb"\n        auth = "Container"\n    />})
             end
           end
@@ -539,14 +508,14 @@ describe 'jira' do
           context 'disable notifications' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 disable_notifications: true
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/bin/setenv.sh').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/bin/setenv.sh').
                 with_content(%r{^DISABLE_NOTIFICATIONS=})
             end
           end
@@ -554,14 +523,14 @@ describe 'jira' do
           context 'native ssl support default params' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 tomcat_native_ssl: true
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                 with_content(%r{redirectPort="8443"}).
                 with_content(%r{port="8443"}).
                 with_content(%r{keyAlias="jira"}).
@@ -576,7 +545,7 @@ describe 'jira' do
           context 'native ssl support custom params' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 tomcat_native_ssl: true,
                 tomcat_https_port: 9443,
@@ -591,7 +560,7 @@ describe 'jira' do
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
                 with_content(%r{redirectPort="9443"}).
                 with_content(%r{port="9443"}).
                 with_content(%r{keyAlias="keystorealias"}).
@@ -607,7 +576,7 @@ describe 'jira' do
           context 'enable secure admin sessions' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 enable_secure_admin_sessions: true
               }
@@ -622,7 +591,7 @@ describe 'jira' do
           context 'disable secure admin sessions' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 enable_secure_admin_sessions: false
               }
@@ -637,7 +606,7 @@ describe 'jira' do
           context 'jira-config.properties' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 jira_config_properties: {
                   'ops.bar.group.size.opsbar-transitions' => '4'
@@ -655,7 +624,7 @@ describe 'jira' do
           context 'enable clustering' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 datacenter: true,
                 shared_homedir: '/mnt/jira_shared_home_dir'
@@ -672,7 +641,7 @@ describe 'jira' do
           context 'enable clustering with ehcache options' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 datacenter: true,
                 shared_homedir: '/mnt/jira_shared_home_dir',
@@ -695,7 +664,7 @@ describe 'jira' do
           context 'jira-8.12 - OpenJDK jvm params' do
             let(:params) do
               {
-                version: '8.12.1',
+                version: '8.16.0',
                 javahome: '/opt/java',
                 jvm_type: 'openjdk-11'
               }
@@ -703,28 +672,28 @@ describe 'jira' do
 
             it { is_expected.to compile.with_all_deps }
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/bin/setenv.sh').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.16.0-standalone/bin/setenv.sh').
                 with_content(%r{#DISABLE_NOTIFICATIONS=}).
                 with_content(%r{JVM_SUPPORT_RECOMMENDED_ARGS='\S+HeapDumpOnOutOfMemoryError}).
                 with_content(%r{JVM_GC_ARGS='.+ \-XX:\+ExplicitGCInvokesConcurrent}).
                 with_content(%r{JVM_CODE_CACHE_ARGS='\S+InitialCodeCacheSize=32m \S+ReservedCodeCacheSize=512m}).
                 with_content(%r{JVM_REQUIRED_ARGS='.+InterningDocumentFactory})
             end
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/bin/user.sh') }
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/conf/server.xml') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.16.0-standalone/bin/user.sh') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.16.0-standalone/conf/server.xml') }
             it do
               is_expected.to contain_file('/home/jira/dbconfig.xml').
                 with_content(%r{jdbc:postgresql://localhost:5432/jira}).
                 with_content(%r{<schema-name>public</schema-name>})
             end
             it { is_expected.not_to contain_file('/home/jira/cluster.properties') }
-            it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/bin/check-java.sh') }
+            it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-software-8.16.0-standalone/bin/check-java.sh') }
           end
 
           context 'jira-8.12 - custom jvm params' do
             let(:params) do
               {
-                version: '8.12.1',
+                version: '8.16.0',
                 javahome: '/opt/java',
                 jvm_type: 'custom',
                 jvm_optional: '-XX:-TEST_OPTIONAL',
@@ -736,28 +705,28 @@ describe 'jira' do
 
             it { is_expected.to compile.with_all_deps }
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/bin/setenv.sh').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.16.0-standalone/bin/setenv.sh').
                 with_content(%r{#DISABLE_NOTIFICATIONS=}).
                 with_content(%r{JVM_SUPPORT_RECOMMENDED_ARGS=\S+TEST_OPTIONAL}).
                 with_content(%r{JVM_GC_ARGS=\S+TEST_GC_ARG}).
                 with_content(%r{JVM_CODE_CACHE_ARGS=\S+TEST_CODECACHE}).
                 with_content(%r{JVM_EXTRA_ARGS=\S+TEST_EXTRA})
             end
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/bin/user.sh') }
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/conf/server.xml') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.16.0-standalone/bin/user.sh') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.16.0-standalone/conf/server.xml') }
             it do
               is_expected.to contain_file('/home/jira/dbconfig.xml').
                 with_content(%r{jdbc:postgresql://localhost:5432/jira}).
                 with_content(%r{<schema-name>public</schema-name>})
             end
             it { is_expected.not_to contain_file('/home/jira/cluster.properties') }
-            it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/bin/check-java.sh') }
+            it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-software-8.16.0-standalone/bin/check-java.sh') }
           end
 
           context 'jira-8.12 - openjdk-11 with additional jvm params' do
             let(:params) do
               {
-                version: '8.12.1',
+                version: '8.16.0',
                 javahome: '/opt/java',
                 jvm_type: 'openjdk-11',
                 jvm_optional: '-XX:-TEST_OPTIONAL',
@@ -769,16 +738,16 @@ describe 'jira' do
 
             it { is_expected.to compile.with_all_deps }
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/bin/setenv.sh').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.16.0-standalone/bin/setenv.sh').
                 with_content(%r{JVM_SUPPORT_RECOMMENDED_ARGS='.+TEST_OPTIONAL'}).
                 with_content(%r{JVM_GC_ARGS='.+TEST_GC_ARG'}).
                 with_content(%r{JVM_CODE_CACHE_ARGS='.+TEST_CODECACHE'}).
                 with_content(%r{JVM_EXTRA_ARGS='.+TEST_EXTRA'})
             end
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/bin/user.sh') }
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/conf/server.xml') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.16.0-standalone/bin/user.sh') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.16.0-standalone/conf/server.xml') }
             it { is_expected.not_to contain_file('/home/jira/cluster.properties') }
-            it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-software-8.12.1-standalone/bin/check-java.sh') }
+            it { is_expected.not_to contain_file('/opt/jira/atlassian-jira-software-8.16.0-standalone/bin/check-java.sh') }
           end
         end
       end

--- a/spec/classes/jira_install_spec.rb
+++ b/spec/classes/jira_install_spec.rb
@@ -17,9 +17,8 @@ describe 'jira' do
                 group:        'jira',
                 installdir:   '/opt/jira',
                 homedir:      '/home/jira',
-                format:       'tar.gz',
                 product:      'jira',
-                version:      '6.3.4a',
+                version:      '8.13.5',
                 download_url: 'https://product-downloads.atlassian.com/software/jira/downloads'
               }
             end
@@ -27,11 +26,11 @@ describe 'jira' do
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_group('jira') }
             it { is_expected.to contain_user('jira').with_shell('/bin/true') }
-            it 'deploys jira 6.3.4a from tar.gz' do
-              is_expected.to contain_archive('/tmp/atlassian-jira-6.3.4a.tar.gz').
-                with('extract_path'  => '/opt/jira/atlassian-jira-6.3.4a-standalone',
-                     'source'        => 'https://product-downloads.atlassian.com/software/jira/downloads/atlassian-jira-6.3.4a.tar.gz',
-                     'creates'       => '/opt/jira/atlassian-jira-6.3.4a-standalone/conf',
+            it 'deploys jira 8.13.5 from tar.gz' do
+              is_expected.to contain_archive('/tmp/atlassian-jira-software-8.13.5.tar.gz').
+                with('extract_path'  => '/opt/jira/atlassian-jira-software-8.13.5-standalone',
+                     'source'        => 'https://product-downloads.atlassian.com/software/jira/downloads/atlassian-jira-software-8.13.5.tar.gz',
+                     'creates'       => '/opt/jira/atlassian-jira-software-8.13.5-standalone/conf',
                      'user'          => 'jira',
                      'group'         => 'jira',
                      'checksum_type' => 'md5')
@@ -44,23 +43,23 @@ describe 'jira' do
             end
           end
 
-          context 'jira 7' do
+          context 'jira version 8.16.0' do
             context 'default product' do
               let(:params) do
                 {
                   javahome:     '/opt/java',
                   installdir:   '/opt/jira',
                   product:      'jira',
-                  version:      '7.0.4',
+                  version:      '8.16.0',
                   download_url: 'http://www.atlassian.com/software/jira/downloads/binary'
                 }
               end
 
-              it 'deploys jira 7.0.4 from tar.gz' do
-                is_expected.to contain_archive('/tmp/atlassian-jira-software-7.0.4-jira-7.0.4.tar.gz').
-                  with('extract_path'  => '/opt/jira/atlassian-jira-software-7.0.4-standalone',
-                       'source'        => 'http://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-7.0.4-jira-7.0.4.tar.gz',
-                       'creates'       => '/opt/jira/atlassian-jira-software-7.0.4-standalone/conf',
+              it 'deploys jira 8.16.0 from tar.gz' do
+                is_expected.to contain_archive('/tmp/atlassian-jira-software-8.16.0.tar.gz').
+                  with('extract_path'  => '/opt/jira/atlassian-jira-software-8.16.0-standalone',
+                       'source'        => 'http://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-8.16.0.tar.gz',
+                       'creates'       => '/opt/jira/atlassian-jira-software-8.16.0-standalone/conf',
                        'user'          => 'jira',
                        'group'         => 'jira',
                        'checksum_type' => 'md5')
@@ -72,16 +71,16 @@ describe 'jira' do
                   javahome:     '/opt/java',
                   installdir:   '/opt/jira',
                   product:      'jira-core',
-                  version:      '7.0.4',
+                  version:      '8.1.0',
                   download_url: 'http://www.atlassian.com/software/jira/downloads/binary'
                 }
               end
 
-              it 'deploys jira 7.0.4 from tar.gz' do
-                is_expected.to contain_archive('/tmp/atlassian-jira-core-7.0.4.tar.gz').
-                  with('extract_path'  => '/opt/jira/atlassian-jira-core-7.0.4-standalone',
-                       'source'        => 'http://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-core-7.0.4.tar.gz',
-                       'creates'       => '/opt/jira/atlassian-jira-core-7.0.4-standalone/conf',
+              it 'deploys jira 8.1.0 from tar.gz' do
+                is_expected.to contain_archive('/tmp/atlassian-jira-core-8.1.0.tar.gz').
+                  with('extract_path'  => '/opt/jira/atlassian-jira-core-8.1.0-standalone',
+                       'source'        => 'http://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-core-8.1.0.tar.gz',
+                       'creates'       => '/opt/jira/atlassian-jira-core-8.1.0-standalone/conf',
                        'user'          => 'jira',
                        'group'         => 'jira',
                        'checksum_type' => 'md5')
@@ -114,8 +113,7 @@ group {'jira':}
             let(:params) do
               {
                 javahome:     '/opt/java',
-                version:      '6.1',
-                format:       'tar.gz',
+                version:      '8.5.0',
                 installdir:   '/opt/jira',
                 homedir:      '/random/homedir',
                 user:         'foo',
@@ -135,11 +133,11 @@ group {'jira':}
             end
             it { is_expected.to contain_group('bar') }
 
-            it 'deploys jira 6.1 from tar.gz' do
-              is_expected.to contain_archive('/tmp/atlassian-jira-6.1.tar.gz').
-                with('extract_path'  => '/opt/jira/atlassian-jira-6.1-standalone',
-                     'source'        => 'https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-6.1.tar.gz',
-                     'creates'       => '/opt/jira/atlassian-jira-6.1-standalone/conf',
+            it 'deploys jira 8.5.0 from tar.gz' do
+              is_expected.to contain_archive('/tmp/atlassian-jira-software-8.5.0.tar.gz').
+                with('extract_path'  => '/opt/jira/atlassian-jira-software-8.5.0-standalone',
+                     'source'        => 'https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-8.5.0.tar.gz',
+                     'creates'       => '/opt/jira/atlassian-jira-software-8.5.0-standalone/conf',
                      'user'          => 'foo',
                      'group'         => 'bar',
                      'checksum_type' => 'md5')

--- a/spec/classes/jira_mysql_connector_spec.rb
+++ b/spec/classes/jira_mysql_connector_spec.rb
@@ -12,7 +12,7 @@ describe 'jira' do
           context 'mysql connector defaults' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 db: 'mysql',
                 mysql_connector_version: '5.1.34'
@@ -22,7 +22,7 @@ describe 'jira' do
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_file('/opt/MySQL-connector').with_ensure('directory') }
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/lib/mysql-connector-java.jar').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/lib/mysql-connector-java.jar').
                 with(
                   'ensure' => 'link',
                   'target' => '/opt/MySQL-connector/mysql-connector-java-5.1.34/mysql-connector-java-5.1.34-bin.jar'
@@ -37,7 +37,7 @@ describe 'jira' do
           context 'mysql connector defaults Connector Version >8' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 db: 'mysql',
                 mysql_connector_version: '8.0.23'
@@ -47,7 +47,7 @@ describe 'jira' do
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_file('/opt/MySQL-connector').with_ensure('directory') }
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/lib/mysql-connector-java.jar').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/lib/mysql-connector-java.jar').
                 with(
                   'ensure' => 'link',
                   'target' => '/opt/MySQL-connector/mysql-connector-java-8.0.23/mysql-connector-java-8.0.23.jar'
@@ -62,7 +62,7 @@ describe 'jira' do
           context 'mysql connector overwrite params' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 db: 'mysql',
                 mysql_connector_version: '5.1.15',
@@ -74,7 +74,7 @@ describe 'jira' do
 
             it { is_expected.to contain_file('/opt/foo').with_ensure('directory') }
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/lib/mysql-connector-java.jar').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/lib/mysql-connector-java.jar').
                 with(
                   'ensure' => 'link',
                   'target' => '/opt/foo/mysql-connector-java-5.1.15/mysql-connector-java-5.1.15-bin.jar'
@@ -89,7 +89,7 @@ describe 'jira' do
           context 'mysql_connector_mangage equals false' do
             let(:params) do
               {
-                version: '6.3.4a',
+                version: '8.13.5',
                 javahome: '/opt/java',
                 db: 'mysql',
                 mysql_connector_manage: false

--- a/spec/classes/jira_sso_spec.rb
+++ b/spec/classes/jira_sso_spec.rb
@@ -13,27 +13,27 @@ describe 'jira' do
             let(:params) do
               {
                 javahome: '/opt/java',
-                version: '6.3.4a',
+                version: '8.13.5',
                 enable_sso: true
               }
             end
 
             it { is_expected.to compile.with_all_deps }
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/seraph-config.xml') }
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/crowd.properties') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/atlassian-jira/WEB-INF/classes/seraph-config.xml') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/atlassian-jira/WEB-INF/classes/crowd.properties') }
           end
           context 'with param application_name set to appname' do
             let(:params) do
               {
                 javahome: '/opt/java',
-                version: '6.3.4a',
+                version: '8.13.5',
                 enable_sso: true,
                 application_name: 'appname'
               }
             end
 
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/crowd.properties').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/atlassian-jira/WEB-INF/classes/crowd.properties').
                 with_content(%r{application.name                        appname})
             end
           end
@@ -41,7 +41,7 @@ describe 'jira' do
             let(:params) do
               {
                 javahome: '/opt/java',
-                version: '6.3.4a',
+                version: '8.13.5',
                 enable_sso: true,
                 application_name: 'app',
                 application_password: 'password',
@@ -51,9 +51,9 @@ describe 'jira' do
               }
             end
 
-            it { is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/seraph-config.xml') }
+            it { is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/atlassian-jira/WEB-INF/classes/seraph-config.xml') }
             it do
-              is_expected.to contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/atlassian-jira/WEB-INF/classes/crowd.properties').
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/atlassian-jira/WEB-INF/classes/crowd.properties').
                 with_content(%r{application.name                        app}).
                 with_content(%r{application.password                    password}).
                 with_content(%r{application.login.url                   https://login.url/}).

--- a/spec/classes/jira_upgrade_spec.rb
+++ b/spec/classes/jira_upgrade_spec.rb
@@ -14,7 +14,7 @@ describe 'jira' do
               { javahome: '/opt/java' }
             end
             let(:facts) do
-              facts.merge(jira_version: '6.3.4a')
+              facts.merge(jira_version: '8.0.0')
             end
 
             it { is_expected.to compile.with_all_deps }
@@ -28,7 +28,7 @@ describe 'jira' do
               }
             end
             let(:facts) do
-              facts.merge(jira_version: '6.3.4a')
+              facts.merge(jira_version: '8.0.0')
             end
 
             it { is_expected.to contain_exec('stop service please') }

--- a/spec/default_module_facts.yml
+++ b/spec/default_module_facts.yml
@@ -1,2 +1,2 @@
 ---
-jira_version: '6.4'
+jira_version: '8.0.0'

--- a/templates/server.xml.epp
+++ b/templates/server.xml.epp
@@ -22,21 +22,15 @@
     <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener"/>
     <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener"/>
 
-<%- if versioncmp($jira::version, '6.4.14') <= 0 and $jira::product =~ /^jira/ { -%>
-    <Listener className="org.apache.catalina.core.JasperListener"/>
-<% } else { -%>
     <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
-<%- } -%>
 
     <Service name="Catalina">
         <Connector port="<%= $jira::tomcat_port %>"
                    <%- if $jira::tomcat_address { -%>
                    address="<%= $jira::tomcat_address %>"
                    <%- } -%>
-                   <%- if (versioncmp($jira::version, '7.12.1') > 0 and $jira::product =~ /^jira/ ) or $jira::product =~ /^servicedesk/ { -%>
                    relaxedPathChars="[]|"
                    relaxedQueryChars="[]|{}^&#x5c;&#x60;&quot;&lt;&gt;"
-                   <%- } -%>
                    maxThreads="<%= $jira::tomcat_max_threads %>"
                    minSpareThreads="<%= $jira::tomcat_min_spare_threads %>"
                    connectionTimeout="<%= $jira::tomcat_connection_timeout %>"
@@ -69,10 +63,8 @@
                     <%- if $jira::tomcat_address { -%>
                     address="<%= $jira::tomcat_address %>"
                     <%- } -%>
-                    <%- if ( versioncmp($jira::version, '7.12.1') > 0 and $jira::product =~ /^jira/ ) or $jira::product =~ /^servicedesk/ { -%>
                     relaxedPathChars="[]|"
                     relaxedQueryChars="[]|{}^&#x5c;&#x60;&quot;&lt;&gt;"
-                    <%- } -%>
                     maxHttpHeaderSize="<%= $jira::tomcat_max_http_header_size %>"
                     SSLEnabled="true"
                     maxThreads="<%= $jira::tomcat_max_threads %>"


### PR DESCRIPTION
Anything pre jira 8.0.0 is already EOL.

Drop support; legacy users can still use the old version of the module and use it to upgrade.

This only fixes manifests, I'll do templates separately. EDIT: ended up fixing templates anyway...