### PR TITLE
Add newer OSes and Puppet 7 to test matrix, drop Puppet 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,5 +71,9 @@ jobs:
       - name: Run tests
         run: bundle exec rake beaker
         env:
+          # Yes, this should be in modulesync, but for now, just work around weird test failures
+          # caused by locale on CentOS 7 with Puppet 7
+          LANG: en_US
+          LC_ALL: en_US.UTF-8
           BEAKER_PUPPET_COLLECTION: ${{ matrix.puppet.collection }}
           BEAKER_setfile: ${{ matrix.setfile.value }}

--- a/metadata.json
+++ b/metadata.json
@@ -24,7 +24,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -24,26 +24,26 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.8 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "7", "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
+        "7", "8"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "7"
+        "7", "8"
       ]
     },
     {


### PR DESCRIPTION
Let's see what the tests say about this. Fixes #361 
