### PR TITLE
Add support for Oracle service names

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,11 @@ The default value is 'public' for PostgreSQL, and undef for others
 This parameter is not required nor do we recommend setting it. However it can be
 used to customize the database connection string.
 
+##### `$oracle_use_sid`
+
+Controls whether the module will use SID or service name syntax for the database URL.
+Only has an effect if `$dbtype` is oracle. Defaults to true
+
 ##### `$pool_max_size`
 
 Setting most of the advanced JDBC parameters is not required unless you want to tune JIRA

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -94,10 +94,12 @@ class jira::config {
     $dburl_real = $jira::dburl
   }
   else {
+    # SIDs use :, service names use /
+    $oracle_separator = bool2str($jira::oracle_use_sid, ':', '/')
     $dburl_real = $jira::db ? {
       'postgresql' => "jdbc:${jira::db}://${jira::dbserver}:${dbport_real}/${jira::dbname}",
       'mysql'      => "jdbc:${jira::db}://${jira::dbserver}:${dbport_real}/${jira::dbname}?useUnicode=true&amp;characterEncoding=UTF8&amp;sessionVariables=default_storage_engine=InnoDB",
-      'oracle'     => "jdbc:${jira::db}:thin:@${jira::dbserver}:${dbport_real}:${jira::dbname}",
+      'oracle'     => "jdbc:${jira::db}:thin:@${jira::dbserver}:${dbport_real}${oracle_separator}${jira::dbname}",
       'sqlserver'  => "jdbc:jtds:${jira::db}://${jira::dbserver}:${dbport_real}/${jira::dbname}",
       'h2'         => "jdbc:h2:file:/${jira::homedir}/database/${jira::dbname}",
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,6 +62,7 @@ class jira (
   Optional[String] $dbtype                                          = undef,
   Optional[String] $dburl                                           = undef,
   Optional[String] $connection_settings                             = undef,
+  Boolean $oracle_use_sid                                           = true,
   $dbschema                                                         = undef,
   # MySQL Connector Settings
   $mysql_connector_manage                                           = true,

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -89,6 +89,43 @@ describe 'jira' do
             end
           end
 
+          context 'oracle params' do
+            let(:params) do
+              {
+                version: '8.13.5',
+                javahome: '/opt/java',
+                db: 'oracle',
+                dbname: 'mydatabase',
+              }
+            end
+
+            it do
+              is_expected.to contain_file('/home/jira/dbconfig.xml').
+                with_content(%r{jdbc:oracle:thin:@localhost:1521:mydatabase}).
+                with_content(%r{<database-type>oracle10g}).
+                with_content(%r{<driver-class>oracle.jdbc.OracleDriver})
+            end
+          end
+
+          context 'oracle servicename' do
+            let(:params) do
+              {
+                version: '8.13.5',
+                javahome: '/opt/java',
+                db: 'oracle',
+                dbport: 1522,
+                dbserver: 'oracleserver',
+                oracle_use_sid: false,
+                dbname: 'mydatabase',
+              }
+            end
+
+            it do
+              is_expected.to contain_file('/home/jira/dbconfig.xml').
+                with_content(%r{jdbc:oracle:thin:@oracleserver:1522/mydatabase})
+            end
+          end
+
           context 'sqlserver params' do
             let(:params) do
               {


### PR DESCRIPTION
Add support for Oracle service names

Adds $oracle_use_sid, that if set to false modified the JDBC
URL syntax to connect to an Oracle database via a service name.

Also, tests.
  
Fixes #283