### PR TITLE
Extend the version check to the tailored jira servicedesk version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -412,7 +412,7 @@ class jira (
   Optional[Integer[0]] $poolsize                                    = undef,
   Optional[Boolean] $enable_connection_pooling                      = undef,
 ) {
-  // To maintain compatibility with previous behaviour, we check for not-servicedesk instead of specifying the 
+  # To maintain compatibility with previous behaviour, we check for not-servicedesk instead of specifying the 
   if $product != 'servicedesk' and versioncmp($jira::version, '8.0.0') < 0 {
     fail('JIRA versions older than 8.0.0 are no longer supported. Please use an older version of this module to upgrade first.')
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -274,7 +274,7 @@ class jira (
 
   # Jira Settings
   String $version                                                   = '8.13.5',
-  String $product                                                   = 'jira',
+  Enum['jira', 'servicedesk', 'jira-core'] $product                 = 'jira',
   Stdlib::Absolutepath $installdir                                  = '/opt/jira',
   Stdlib::Absolutepath $homedir                                     = '/home/jira',
   Boolean $manage_user                                              = true,
@@ -354,7 +354,7 @@ class jira (
   # Command to stop jira in preparation to upgrade. This is configurable
   # incase the jira service is managed outside of puppet. eg: using the
   # puppetlabs-corosync module: 'crm resource stop jira && sleep 15'
-  # Note: the command should return either 0 or  5 
+  # Note: the command should return either 0 or  5
   # when the service doesn't exist
   String $stop_jira                                                 = 'systemctl stop jira.service && sleep 15',
   # Whether to manage the 'check-java.sh' script, and where to retrieve
@@ -412,8 +412,11 @@ class jira (
   Optional[Integer[0]] $poolsize                                    = undef,
   Optional[Boolean] $enable_connection_pooling                      = undef,
 ) {
-  if versioncmp($jira::version, '8.0.0') < 0 {
+  if $product == 'jira' and versioncmp($jira::version, '8.0.0') < 0 {
     fail('JIRA versions older than 8.0.0 are no longer supported. Please use an older version of this module to upgrade first.')
+  }
+  if $product == 'servicedesk' and versioncmp($jira::version, '4.10.0') < 0 {
+    fail('JIRA servicedesk versions older than 4.10.0 are no longer supported. Please use an older version of this module to upgrade first.')
   }
 
   if $datacenter and !$shared_homedir {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -274,7 +274,7 @@ class jira (
 
   # Jira Settings
   String $version                                                   = '8.13.5',
-  Enum['jira', 'servicedesk', 'jira-core'] $product                 = 'jira',
+  String[1] $product                                                = 'jira',
   Stdlib::Absolutepath $installdir                                  = '/opt/jira',
   Stdlib::Absolutepath $homedir                                     = '/home/jira',
   Boolean $manage_user                                              = true,
@@ -412,7 +412,8 @@ class jira (
   Optional[Integer[0]] $poolsize                                    = undef,
   Optional[Boolean] $enable_connection_pooling                      = undef,
 ) {
-  if $product == 'jira' and versioncmp($jira::version, '8.0.0') < 0 {
+  // To maintain compatibility with previous behaviour, we check for not-servicedesk instead of specifying the 
+  if $product != 'servicedesk' and versioncmp($jira::version, '8.0.0') < 0 {
     fail('JIRA versions older than 8.0.0 are no longer supported. Please use an older version of this module to upgrade first.')
   }
   if $product == 'servicedesk' and versioncmp($jira::version, '4.10.0') < 0 {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The current version check does not take the JIRA servicedesk package into account. This package has an other versioning schema - see here: https://www.atlassian.com/de/software/jira/service-management/download-archives

#### This Pull Request (PR) fixes the following issues
Currently, if the following parameters are choosen to init the jira class, the output shows

`JIRA versions older than 8.0.0 are no longer supported. Please use an older version of this module to upgrade first`

```puppet
class { 'jira':
    #
    # JIRA parameters
    version   => '4.17.0',
    product  => 'servicedesk',
...
```