### PR TITLE
use variable instead of literal in server.xml

### DIFF
--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -438,6 +438,36 @@ describe 'jira' do
             end
           end
 
+          context 'tomcat proxy path native ssl default params' do
+            let(:params) do
+              {
+                version: '8.13.5',
+                javahome: '/opt/java',
+                proxy: {
+                  'scheme'    => 'https',
+                  'proxyName' => 'www.example.com',
+                  'proxyPort' => '9999'
+                },
+                tomcat_native_ssl: true
+              }
+            end
+
+            it do
+              is_expected.to contain_file('/opt/jira/atlassian-jira-software-8.13.5-standalone/conf/server.xml').
+                with_content(%r{proxyName = 'www\.example\.com'}).
+                with_content(%r{scheme = 'https'}).
+                with_content(%r{proxyPort = '9999'}).
+                with_content(%r{redirectPort="8443"}).
+                with_content(%r{port="8443"}).
+                with_content(%r{keyAlias="jira"}).
+                with_content(%r{keystoreFile="/home/jira/jira.jks"}).
+                with_content(%r{keystorePass="changeit"}).
+                with_content(%r{keystoreType="JKS"}).
+                with_content(%r{port="8443".*acceptCount="100"}m).
+                with_content(%r{port="8443".*maxThreads="150"}m)
+            end
+          end
+
           context 'ajp proxy' do
             context 'with valid config including protocol AJP/1.3' do
               let(:params) do

--- a/templates/server.xml.epp
+++ b/templates/server.xml.epp
@@ -87,7 +87,7 @@
                     keystoreType="<%= $jira::tomcat_keystore_type %>"
 <%   if $jira::proxy { -%>
 <%     jira::sort_hash($jira::proxy).each |$key, $value| { -%>
-                    <%= key %> = '<%= $value %>'
+                    <%= $key %> = '<%= $value %>'
 <%     } -%>
 <%   } -%>
         />


### PR DESCRIPTION
#### Pull Request (PR) description
Using the `proxy` parameter when `tomcat_native_ssl` is true results in a string literal of "key" in server.xml in the SSL connector.

Pull request address that by using the previously declared `$key` variable in the EPP template.

#### This Pull Request (PR) fixes the following issues
n/a