### PR TITLE
Avoid duplicate scheme declaration when using proxy with SSL

### DIFF
--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -503,13 +503,39 @@ describe 'jira' do
 
             it do
               is_expected.to contain_file(FILENAME_SERVER_XML).
+                without_content(%r{scheme="http"}).
                 with_content(%r{proxyName = 'www\.example\.com'}).
                 with_content(%r{scheme = 'https'}).
                 with_content(%r{proxyPort = '9999'})
             end
           end
 
-          context 'tomcat proxy path native ssl default params' do
+          context 'tomcat native ssl default params' do
+            let(:params) do
+              super().merge(
+                tomcat_native_ssl: true
+              )
+            end
+
+            it do
+              is_expected.to contain_file(FILENAME_SERVER_XML).
+                with_content(%r{scheme="http"}).
+                with_content(%r{scheme="https"}).
+                without_content(%r{proxyName = 'www\.example\.com'}).
+                without_content(%r{scheme = 'https'}).
+                without_content(%r{proxyPort = '9999'}).
+                with_content(%r{redirectPort="8443"}).
+                with_content(%r{port="8443"}).
+                with_content(%r{keyAlias="jira"}).
+                with_content(%r{keystoreFile="/home/jira/jira.jks"}).
+                with_content(%r{keystorePass="changeit"}).
+                with_content(%r{keystoreType="JKS"}).
+                with_content(%r{port="8443".*acceptCount="100"}m).
+                with_content(%r{port="8443".*maxThreads="150"}m)
+            end
+          end
+
+          context 'tomcat native ssl default params with proxy path' do
             let(:params) do
               super().merge(
                 proxy: {
@@ -523,17 +549,10 @@ describe 'jira' do
 
             it do
               is_expected.to contain_file(FILENAME_SERVER_XML).
+                without_content(%r{scheme="http"}).
                 with_content(%r{proxyName = 'www\.example\.com'}).
                 with_content(%r{scheme = 'https'}).
-                with_content(%r{proxyPort = '9999'}).
-                with_content(%r{redirectPort="8443"}).
-                with_content(%r{port="8443"}).
-                with_content(%r{keyAlias="jira"}).
-                with_content(%r{keystoreFile="/home/jira/jira.jks"}).
-                with_content(%r{keystorePass="changeit"}).
-                with_content(%r{keystoreType="JKS"}).
-                with_content(%r{port="8443".*acceptCount="100"}m).
-                with_content(%r{port="8443".*maxThreads="150"}m)
+                with_content(%r{proxyPort = '9999'})
             end
           end
 

--- a/templates/server.xml.epp
+++ b/templates/server.xml.epp
@@ -74,7 +74,7 @@
                     enableLookups="<%= $jira::tomcat_enable_lookups %>"
                     disableUploadTimeout="<%= $jira::tomcat_disable_upload_timeout %>"
                     acceptCount="<%= $jira::tomcat_accept_count %>"
-<%   if $jira::proxy['scheme'] { -%>
+<%   if ! $jira::proxy['scheme'] { -%>
                     scheme="https"
 <%   } -%>
                     secure="true"


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
- Added negation logic when `scheme` key is present when iterating through the proxy hash.
- Added additional test for `tomcat_native_ssl` without proxy settings.

#### This Pull Request (PR) fixes the following issues
Fixes #395 
