### PR TITLE
ulimit command does not apply to systemd services on all platforms

### DIFF
--- a/templates/jira.service.epp
+++ b/templates/jira.service.epp
@@ -9,6 +9,7 @@ Environment="JAVA_HOME=<%= $jira::javahome %>"
 User=<%= $jira::user %>
 ExecStart=<%= $jira::webappdir %>/bin/start-jira.sh
 ExecStop=<%= $jira::webappdir %>/bin/stop-jira.sh
+LimitNOFILE=<%= $jira::jvm_nofiles_limit %>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Services started with systemd on CentOS 7, and possibly other platforms ignore ulimit unless the `LimitNOFILE` parameter is set in the systemd unit file.

https://bugzilla.redhat.com/show_bug.cgi?id=754285