### PR TITLE
Fix if statement in setenv template to work with service desk projects

### DIFF
--- a/templates/setenv.sh.epp
+++ b/templates/setenv.sh.epp
@@ -38,7 +38,7 @@ JVM_CODE_CACHE_ARGS='<%= pick_default($jira::jvm_code_cache_args, $jira::config:
 #
 # The following are the required arguments for Jira.
 #
-<%- if versioncmp($jira::version, '8.11.0') > 0 { -%>
+<%- if ($project == "servicedesk") and (versioncmp($jira::version, '8.11.0') > 0) or ($project != "servicedesk") and (versioncmp($jira::version, '4.11.0') > 0){ -%>
 JVM_REQUIRED_ARGS='-Djava.awt.headless=true -Datlassian.standalone=JIRA -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true -Dmail.mime.decodeparameters=true -Dorg.dom4j.factory=com.atlassian.core.xml.InterningDocumentFactory'
 <% } else { -%>
 JVM_REQUIRED_ARGS='-Djava.awt.headless=true -Datlassian.standalone=JIRA -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true -Dmail.mime.decodeparameters=true'


### PR DESCRIPTION
#### Pull Request (PR) description
The version variable in puppet-jira can be either set to the jira software version or the servicedesk version. manifests/init.pp correctly differentiates but this template if statement does not, so the if statement does not apply to servicedesk > 4.11, missing out on an essential JVM parameter.

#### This Pull Request (PR) fixes the following issues
n/a