### PR TITLE
change cluster nodeid to hostname

### DIFF
--- a/templates/cluster.properties.epp
+++ b/templates/cluster.properties.epp
@@ -1,5 +1,5 @@
 # This ID must be unique across the cluster
-jira.node.id = <%= $facts['fqdn'] %>
+jira.node.id = <%= $facts['hostname'] %>
 # The location of the shared home directory for all JIRA nodes
 jira.shared.home = <%= $jira::shared_homedir %>
 <% if $jira::ehcache_listener_host { -%>


### PR DESCRIPTION
As fqdn could be longer than 60 characters in some cases, causing the cluster node to not start.

tests:
```
Finished in 3 minutes 30.9 seconds (files took 6.55 seconds to load)
1213 examples, 0 failures
```

 
