### PR TITLE
Bugfix java 17 support per atlassian upstream

### DIFF
--- a/templates/setenv.sh.epp
+++ b/templates/setenv.sh.epp
@@ -89,6 +89,14 @@ fi
 
 JAVA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} ${JVM_CODE_CACHE_ARGS} ${JAVA_OPTS} ${JVM_REQUIRED_ARGS} ${DISABLE_NOTIFICATIONS} ${JVM_SUPPORT_RECOMMENDED_ARGS} ${JVM_EXTRA_ARGS} ${JIRA_HOME_MINUSD} ${START_JIRA_JAVA_OPTS}"
 
+j_ver=`echo "$($JAVA_HOME/bin/java -version 2>&1)" | grep "version" | awk '{ print substr($3, 2, length($3)-2); }'`
+IFS='.' read -a j_ver_parts <<< "$j_ver"
+
+if [[ ${j_ver_parts[0]} = 17 ]]; then
+  JVM_OPENS=$(cat $PRGDIR/java-opens.txt)
+  JAVA_OPTS="$JVM_OPENS $JAVA_OPTS"
+fi
+
 export JAVA_OPTS
 
 # DO NOT remove the following line


### PR DESCRIPTION
See https://jira.atlassian.com/browse/JRASERVER-76224 for details on this. This snippet was taken directly from the setenv.sh script from JIRA 9.11.1.

#### Pull Request (PR) description
This PR updates setenv.sh with the fix from atlassian's upstream setenv.sh script. It simply checks if java 17 is in use, and if so, then it includes the JVM_OPENS parameters.

#### This Pull Request (PR) fixes the following issues
Fixes #412 