### PR TITLE
Add "change database password" parameter - JIRA >10.3

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -81,6 +81,7 @@ The following parameters are available in the `jira` class:
 * [`db`](#-jira--db)
 * [`dbname`](#-jira--dbname)
 * [`dbuser`](#-jira--dbuser)
+* [`change_dbpassword`](#-jira--change_dbpassword)
 * [`dbpassword`](#-jira--dbpassword)
 * [`dbserver`](#-jira--dbserver)
 * [`dbport`](#-jira--dbport)
@@ -390,6 +391,14 @@ Data type: `String`
 Database username
 
 Default value: `'jiraadm'`
+
+##### <a name="-jira--change_dbpassword"></a>`change_dbpassword`
+
+Data type: `Boolean`
+
+Set to true to actually generate a dbconfig.xml with the password - otherwise write "{ATL_SECURED}"
+
+Default value: `false`
 
 ##### <a name="-jira--dbpassword"></a>`dbpassword`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -82,7 +82,6 @@ The following parameters are available in the `jira` class:
 * [`dbname`](#-jira--dbname)
 * [`change_dbpassword`](#-jira--change_dbpassword)
 * [`dbuser`](#-jira--dbuser)
-* [`change_dbpassword`](#-jira--change_dbpassword)
 * [`dbpassword`](#-jira--dbpassword)
 * [`dbserver`](#-jira--dbserver)
 * [`dbport`](#-jira--dbport)
@@ -400,14 +399,6 @@ Data type: `String`
 Database username
 
 Default value: `'jiraadm'`
-
-##### <a name="-jira--change_dbpassword"></a>`change_dbpassword`
-
-Data type: `Boolean`
-
-Set to true to actually generate a dbconfig.xml with the password - otherwise write "{ATL_SECURED}"
-
-Default value: `false`
 
 ##### <a name="-jira--dbpassword"></a>`dbpassword`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,7 +47,9 @@ class jira::config {
       fail('You need to set jira::tomcat_native_ssl to true when using jira::tomcat_redirect_https_port')
     }
   }
-
+  
+  $change_dbpassword = $jira::change_dbpassword
+  
   if $jira::dbport {
     $dbport = $jira::dbport
   } else {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,7 +47,7 @@ class jira::config {
       fail('You need to set jira::tomcat_native_ssl to true when using jira::tomcat_redirect_https_port')
     }
   }
-  
+
   $change_dbpassword = $jira::change_dbpassword
 
   if $jira::dbport {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,7 +47,7 @@ class jira::config {
       fail('You need to set jira::tomcat_native_ssl to true when using jira::tomcat_redirect_https_port')
     }
   }
-
+  
   $change_dbpassword = $jira::change_dbpassword
 
   if $jira::dbport {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -49,7 +49,7 @@ class jira::config {
   }
   
   $change_dbpassword = $jira::change_dbpassword
-  
+
   if $jira::dbport {
     $dbport = $jira::dbport
   } else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,6 +68,8 @@
 #   The kind of database to use.
 # @param dbname
 #   The database name to connect to
+# @param change_dbpassword
+#   Set to true to actually generate a dbconfig.xml with the password - otherwise write "{ATL_SECURED}"
 # @param dbuser
 #   Database username
 # @param dbpassword
@@ -313,6 +315,7 @@ class jira (
   Boolean $use_jndi_ds                                              = false,
   String[1] $jndi_ds_name                                           = 'JiraDS',
   Enum['postgresql','mysql','sqlserver','oracle','h2'] $db          = 'postgresql',
+  Boolean $change_dbpassword                                        = false,
   String $dbuser                                                    = 'jiraadm',
   String $dbpassword                                                = 'mypassword',
   String $dbserver                                                  = 'localhost',

--- a/spec/acceptance/default_parameters_spec.rb
+++ b/spec/acceptance/default_parameters_spec.rb
@@ -98,11 +98,11 @@ describe 'jira postgresql' do
   describe command('tail -100 ~jira/log/atlassian-jira.log') do
     its(:stdout) { is_expected.to include('INFO') }
   end
-  
+
   describe command('wget -q --tries=54 --retry-connrefused --read-timeout=10 -O- localhost:8080') do
     its(:stdout) { is_expected.to include('8.16.0') }
   end
-  
+
   describe 'shutdown' do
     it { shell('service jira stop', acceptable_exit_codes: [0, 1]) }
     it { shell('pkill -9 -f postgres', acceptable_exit_codes: [0, 1]) }

--- a/spec/acceptance/default_parameters_spec.rb
+++ b/spec/acceptance/default_parameters_spec.rb
@@ -54,6 +54,7 @@ describe 'jira postgresql' do
         java_package             => $java_package,
         javahome                 => $java_home,
         script_check_java_manage => true,
+        change_dbpassword        => true
       }
     EOS
 

--- a/spec/acceptance/default_parameters_spec.rb
+++ b/spec/acceptance/default_parameters_spec.rb
@@ -54,7 +54,7 @@ describe 'jira postgresql' do
         java_package             => $java_package,
         javahome                 => $java_home,
         script_check_java_manage => true,
-        change_dbpassword        => true
+        change_dbpassword        => true,
       }
     EOS
 
@@ -95,10 +95,14 @@ describe 'jira postgresql' do
     it { is_expected.to have_login_shell '/bin/true' }
   end
 
-  describe command('wget -q --tries=24 --retry-connrefused --read-timeout=10 -O- localhost:8080') do
+  describe command('tail -100 ~jira/log/atlassian-jira.log') do
+    its(:stdout) { is_expected.to include('INFO') }
+  end
+  
+  describe command('wget -q --tries=54 --retry-connrefused --read-timeout=10 -O- localhost:8080') do
     its(:stdout) { is_expected.to include('8.16.0') }
   end
-
+  
   describe 'shutdown' do
     it { shell('service jira stop', acceptable_exit_codes: [0, 1]) }
     it { shell('pkill -9 -f postgres', acceptable_exit_codes: [0, 1]) }

--- a/spec/acceptance/mysql_spec.rb
+++ b/spec/acceptance/mysql_spec.rb
@@ -77,6 +77,7 @@ describe 'jira mysql' do
         dbport                   => 3306,
         dbdriver                 => 'com.mysql.jdbc.Driver',
         dbtype                   => 'mysql',
+        change_dbpassword        => true,
         tomcat_port              => 8081,
         tomcat_native_ssl        => true,
         tomcat_keystore_file     => '/tmp/jira.ks',

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -14,6 +14,7 @@ describe 'jira' do
       {
         javahome: '/opt/java',
         version: DEFAULT_VERSION,
+        
       }
     end
 
@@ -172,7 +173,8 @@ describe 'jira' do
                 dbserver: 'TheSQLServer',
                 dbname: 'TheJiraDB',
                 dbuser: 'TheDBUser',
-                dbpassword: 'TheDBPassword'
+                dbpassword: 'TheDBPassword',
+                change_dbpassword: true
               )
             end
 
@@ -195,7 +197,8 @@ describe 'jira' do
                 dbserver: 'TheSQLServer',
                 dbname: 'TheJiraDB',
                 dbuser: 'TheDBUser',
-                dbpassword: 'TheDBPassword'
+                dbpassword: 'TheDBPassword',
+                change_dbpassword: true
               )
             end
 
@@ -237,7 +240,8 @@ describe 'jira' do
                 dbserver: 'TheSQLServer',
                 dbname: 'TheJiraDB',
                 dbuser: 'TheDBUser',
-                dbpassword: 'TheDBPassword'
+                dbpassword: 'TheDBPassword',
+                change_dbpassword: true
               )
             end
 

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -14,7 +14,6 @@ describe 'jira' do
       {
         javahome: '/opt/java',
         version: DEFAULT_VERSION,
-        
       }
     end
 

--- a/templates/dbconfig.xml.epp
+++ b/templates/dbconfig.xml.epp
@@ -12,7 +12,11 @@
     <url><%= $jira::config::dburl %></url>
     <driver-class><%= $jira::config::dbdriver %></driver-class>
     <username><%= $jira::dbuser %></username>
+    <%- if $jira::config::change_dbpassword { -%>
     <password><%= $jira::dbpassword %></password>
+    <%- } else { -%>
+    <password>{ATL_SECURED}</password>
+    <%- } -%>
 <%# For most of these, Jira defaults are better... -%>
 <% if $jira::config::pool_min_size != undef { -%>
     <pool-min-size><%= $jira::config::pool_min_size %></pool-min-size>
@@ -20,14 +24,20 @@
 <% if $jira::config::pool_max_size != undef { -%>
     <pool-max-size><%= $jira::config::pool_max_size %></pool-max-size>
 <% } -%>
-<% if $jira::config::pool_max_idle != undef { -%>
-    <pool-max-idle><%= $jira::config::pool_max_idle %></pool-max-idle>
-<% } -%>
 <% if $jira::config::pool_max_wait != undef { -%>
     <pool-max-wait><%= $jira::config::pool_max_wait %></pool-max-wait>
 <% } -%>
+<% if $jira::config::validation_query != undef { -%>
+    <validation-query><%= $jira::config::validation_query %></validation-query>
+<% } -%>
 <% if $jira::config::min_evictable_idle_time != undef { -%>
     <min-evictable-idle-time-millis><%= $jira::config::min_evictable_idle_time %></min-evictable-idle-time-millis>
+<% } -%>
+<% if $jira::config::time_between_eviction_runs != undef { -%>
+    <time-between-eviction-runs-millis><%= $jira::config::time_between_eviction_runs %></time-between-eviction-runs-millis>
+<% } -%>
+<% if $jira::config::pool_max_idle != undef { -%>
+    <pool-max-idle><%= $jira::config::pool_max_idle %></pool-max-idle>
 <% } -%>
 <% if $jira::config::pool_remove_abandoned != undef { -%>
     <pool-remove-abandoned><%= $jira::config::pool_remove_abandoned %></pool-remove-abandoned>
@@ -35,20 +45,14 @@
 <% if $jira::config::pool_remove_abandoned_timeout != undef { -%>
     <pool-remove-abandoned-timeout><%= $jira::config::pool_remove_abandoned_timeout %></pool-remove-abandoned-timeout>
 <% } -%>
-<% if $jira::config::pool_test_while_idle != undef { -%>
-    <pool-test-while-idle><%= $jira::config::pool_test_while_idle %></pool-test-while-idle>
-<% } -%>
 <% if $jira::config::pool_test_on_borrow != undef { -%>
     <pool-test-on-borrow><%= $jira::config::pool_test_on_borrow %></pool-test-on-borrow>
 <% } -%>
-<% if $jira::config::validation_query != undef { -%>
-    <validation-query><%= $jira::config::validation_query %></validation-query>
+<% if $jira::config::pool_test_while_idle != undef { -%>
+    <pool-test-while-idle><%= $jira::config::pool_test_while_idle %></pool-test-while-idle>
 <% } -%>
 <% if $jira::config::validation_query_timeout != undef { -%>
     <validation-query-timeout><%= $jira::config::validation_query_timeout %></validation-query-timeout>
-<% } -%>
-<% if $jira::config::time_between_eviction_runs != undef { -%>
-    <time-between-eviction-runs-millis><%= $jira::config::time_between_eviction_runs %></time-between-eviction-runs-millis>
 <% } -%>
 <% if $jira::config::connection_settings { -%>
     <connection-properties><%= $jira::config::connection_settings %></connection-properties>


### PR DESCRIPTION

#### Pull Request (PR) description
From JIRA 10.3 on the password in the dbconfig.xml gets replaced with {ATL_SECURED} after JIRA has read-in the password and encrypted it into it's local password store.

#### This Pull Request (PR) fixes the following issues
Add the change_dbpassword parameter. Unless it is set to true the password will not be written into dbconfig.xml