### PR TITLE
`metadata.json`: increase `puppetlabs/stdlib` minimum version to 8.4.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 10.0.0"
+      "version_requirement": ">= 8.4.0 < 10.0.0"
     },
     {
       "name": "puppet/archive",


### PR DESCRIPTION
Commit 7dd0828d518c2664105495887622250fc9ca7910 (#445) introduced stdlib::deferrable_epp() which was introduced in stdlib 8.4.0 in https://github.com/puppetlabs/puppetlabs-stdlib/commit/c1127f26a024c6fd91ecd1de75122670aabb129d.