### PR TITLE
Drop support for EOL Ubuntu 18.04 and Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,14 +268,7 @@ see [REFERENCE.md](REFERENCE.md)
 
 ## Limitations
 
-* Puppet 6.1.0
-* Puppet Enterprise
-
-The puppetlabs repositories can be found at:
-<http://yum.puppetlabs.com/> and <http://apt.puppetlabs.com/>
-
-* RedHat 7, 8 or compatible (CentOS, Oracle Linux, etc)
-* Ubuntu 18.04, 20.04
+See `metadata.json` for supported Puppet platforms and components.
 
 * Jira 8.x
 

--- a/metadata.json
+++ b/metadata.json
@@ -39,7 +39,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]
@@ -47,7 +46,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]
@@ -55,7 +53,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]
@@ -72,12 +69,6 @@
       "operatingsystemrelease": [
         "8",
         "9"
-      ]
-    },
-    {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -80,8 +80,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
-        "20.04",
         "22.04"
       ]
     }

--- a/spec/acceptance/default_parameters_jira_10_spec.rb
+++ b/spec/acceptance/default_parameters_jira_10_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper_acceptance'
 def on_supported_os
   family = fact('os.family')
   major = fact('os.release.major')
-  (family == 'Debian' and (major >= '22.04' or (major >= '11' and major <= '20'))) or (family == 'RedHat' and major >= '8')
+  family == 'Debian' and (major >= '22.04' or (major >= '11' and major <= '20'))
 end
 
 prepare = <<-EOS

--- a/spec/acceptance/mysql_spec.rb
+++ b/spec/acceptance/mysql_spec.rb
@@ -5,28 +5,10 @@ require 'spec_helper_acceptance'
 describe 'jira mysql' do
   it 'installs with defaults' do
     pp = <<-EOS
-      # On ubuntu 20.04 and 22.04 the default is to install mariadb
-      # As the ubuntu 20.04 runner we use in github actions allready has mysql installed
-      # a apparmor error is triggerd when using mariadb in this test..
-      # Forcing the use of mysql
-      if $facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'], '20.04') >= 0 {
-        $mysql_service_name = 'mysql'
-        $mysql_server_package = 'mysql-server'
-        $mysql_client_package = 'mysql-client'
-      } else {
-        $mysql_service_name = undef
-        $mysql_server_package = undef
-        $mysql_client_package = undef
-      }
-
       class { 'mysql::server':
         root_password => 'strongpassword',
-        package_name => $mysql_server_package,
-        service_name => $mysql_service_name,
       }
-      class { 'mysql::client':
-        package_name => $mysql_client_package,
-      }
+      include mysql::client
 
       $cs = 'utf8mb4'
 

--- a/spec/acceptance/mysql_spec.rb
+++ b/spec/acceptance/mysql_spec.rb
@@ -28,13 +28,7 @@ describe 'jira mysql' do
         package_name => $mysql_client_package,
       }
 
-      # Default MySQL is too old for utf8mb4 on CentOS 7, or something. Also Ubuntu 20.04
-      # for some reason fails with utf8
-      if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '7' {
-        $cs = 'utf8'
-      } else {
-        $cs = 'utf8mb4'
-      }
+      $cs = 'utf8mb4'
 
       mysql::db { 'jira':
         charset  => $cs,


### PR DESCRIPTION
- #452
- **Drop support for EOL Ubuntu 18.04 and Ubuntu 20.04**
