### PR TITLE
Add JVM arguments required by Log4j 2.x from Jira 9.5

### DIFF
--- a/templates/setenv.sh.epp
+++ b/templates/setenv.sh.epp
@@ -38,9 +38,11 @@ JVM_CODE_CACHE_ARGS='<%= pick_default($jira::jvm_code_cache_args, $jira::config:
 #
 # The following are the required arguments for Jira.
 #
-<%- if ($jira::product != "servicedesk" and versioncmp($jira::version, '8.11.0') > 0) or ($jira::product == "servicedesk" and (versioncmp($jira::version, '4.11.0') > 0)){ -%>
+<%- if $jira::product != "servicedesk" and versioncmp($jira::version, '9.5.0') >= 0 { -%>
+JVM_REQUIRED_ARGS='-Dlog4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector -Dlog4j2.disableJmx=true -Dlog4j2.garbagefree.threadContextMap=true -Dlog4j2.isWebapp=false -Djava.awt.headless=true -Datlassian.standalone=JIRA -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true -Dmail.mime.decodeparameters=true -Dorg.dom4j.factory=com.atlassian.core.xml.InterningDocumentFactory'
+<%- } elsif ($jira::product != "servicedesk" and versioncmp($jira::version, '8.11.0') > 0) or ($jira::product == "servicedesk" and (versioncmp($jira::version, '4.11.0') > 0)){ -%>
 JVM_REQUIRED_ARGS='-Djava.awt.headless=true -Datlassian.standalone=JIRA -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true -Dmail.mime.decodeparameters=true -Dorg.dom4j.factory=com.atlassian.core.xml.InterningDocumentFactory'
-<% } else { -%>
+<%- } else { -%>
 JVM_REQUIRED_ARGS='-Djava.awt.headless=true -Datlassian.standalone=JIRA -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true -Dmail.mime.decodeparameters=true'
 <%- } -%>
 


### PR DESCRIPTION
#### Pull Request (PR) description
Log4J has been updated to version 2.x on Jira 9.5.x and new JVM arguments have been included by default in the setenv.sh and setenv.bat files coming from fresh Jira installations.

Missing these parameters breaks the runtime log level modification using the Logging and Profiling page.

- https://support.atlassian.com/jira/kb/temporarily-changing-the-logging-level-doesnt-work-and-no-error-is-shown/
- https://jira.atlassian.com/browse/JRASERVER-62838

#### This Pull Request (PR) fixes the following issues

Fixes #459

#### Testing

Tested on Jira 9.12.24 which produced the following changes and fixed the issue mentioned in the KB article:
```
Notice: /Stage[main]/Jira::Config/File[/data00/jira_install/atlassian-jira-software-9.12.24-standalone/bin/setenv.sh]/content:
--- /data00/jira_install/atlassian-jira-software-9.12.24-standalone/bin/setenv.sh	2025-06-15 10:19:46.818031407 +0300
+++ /tmp/puppet-file20250721-2273167-12vd6hb	2025-07-21 13:42:41.966574265 +0300
@@ -36,7 +36,7 @@
 #
 # The following are the required arguments for Jira.
 #
-JVM_REQUIRED_ARGS='-Djava.awt.headless=true -Datlassian.standalone=JIRA -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true -Dmail.mime.decodeparameters=true -Dorg.dom4j.factory=com.atlassian.core.xml.InterningDocumentFactory'
+JVM_REQUIRED_ARGS='-Dlog4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector -Dlog4j2.disableJmx=true -Dlog4j2.garbagefree.threadContextMap=true -Dlog4j2.isWebapp=false -Djava.awt.headless=true -Datlassian.standalone=JIRA -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true -Dmail.mime.decodeparameters=true -Dorg.dom4j.factory=com.atlassian.core.xml.InterningDocumentFactory'
```

For sake of readability, the added parameters (as provided by Atlassian) are:
```
-Dlog4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector 
-Dlog4j2.disableJmx=true 
-Dlog4j2.garbagefree.threadContextMap=true 
-Dlog4j2.isWebapp=false
```

And the rest of the line stays unchanged.

#### Notes

I believe the 'servicedesk' product is no longer relevant, given that it's now called JSM instead and at least in our case I believe it is installed as an app/extension on top of a normal Jira installation with the 'jira' product. 

Please correct me if I'm mistaken here.
