### PR TITLE
Stop setting `socketTimeout` for jira 9.4.0+

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -467,7 +467,8 @@ Default value: `undef`
 Data type: `Optional[String]`
 
 Configures additional JDBC connection properties in dbconfig.xml
-For PostgreSQL, a default value of "tcpKeepAlive=true;socketTimeout=240" will be used
+For PostgreSQL, a default value of "tcpKeepAlive=true;socketTimeout=240" will be used for JIRA < 9.4.0.
+For JIRA >= 9.4.0, the default is "tcpKeepAlive=true".
 See https://confluence.atlassian.com/jirakb/connection-problems-to-postgresql-result-in-stuck-threads-in-jira-1047534091.html
 
 Default value: `undef`

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -151,7 +151,11 @@ class jira::config {
     $jira::connection_settings
   } else {
     $jira::db ? {
-      'postgresql' => 'tcpKeepAlive=true;socketTimeout=240',
+      'postgresql' => if (versioncmp($jira::version, '9.4.0') < 0) {
+        'tcpKeepAlive=true;socketTimeout=240'
+      } else {
+        'tcpKeepAlive=true'
+      },
       default => undef,
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,7 +88,8 @@
 #   Set this if you wish to use a custom database URL
 # @param connection_settings
 #   Configures additional JDBC connection properties in dbconfig.xml
-#   For PostgreSQL, a default value of "tcpKeepAlive=true;socketTimeout=240" will be used
+#   For PostgreSQL, a default value of "tcpKeepAlive=true;socketTimeout=240" will be used for JIRA < 9.4.0.
+#   For JIRA >= 9.4.0, the default is "tcpKeepAlive=true".
 #   See https://confluence.atlassian.com/jirakb/connection-problems-to-postgresql-result-in-stuck-threads-in-jira-1047534091.html
 # @param oracle_use_sid
 #   Affects the database URL format for Oracle depending on whether you connect via a SID or a service name

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -1647,6 +1647,21 @@ describe 'jira' do
               end
             end
           end
+
+          context 'with version >= 9.4.0' do
+            let(:params) do
+              {
+                javahome: '/opt/java',
+                version: '9.4.0',
+              }
+            end
+
+            it do
+              is_expected.to contain_file(FILENAME_DBCONFIG_XML).
+                with_content(%r{<connection-properties>tcpKeepAlive=true}).
+                without_content(%r{socketTimeout=240})
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
#### Pull Request (PR) description

Stop setting `socketTimeout` for Jira 9.4.0+.

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-jira/issues/448
